### PR TITLE
Add admin client and finish cluster networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,15 +6,25 @@ dependencies = [
  "mio 0.4.0 (git+https://github.com/carllerche/mio.git)",
  "msgpack 0.1.0 (git+https://github.com/mneumann/rust-msgpack.git)",
  "quickcheck 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aster"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -38,6 +48,15 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -72,7 +91,7 @@ version = "0.1.0"
 source = "git+https://github.com/mneumann/rust-msgpack.git#03d7c62191a0aa5fde19a57ceca5925ee0ab4f03"
 dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -89,8 +108,8 @@ name = "num"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -103,7 +122,7 @@ name = "quasi_codegen"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -120,20 +139,22 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -149,7 +170,7 @@ name = "serde_codegen"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi_macros 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -168,10 +189,30 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "time"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.1.23"
 source = "git+https://github.com/retep998/winapi-rs#98441aab7d3e3c301f70b46751e0f60cc55052f5"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ serde = "*"
 serde_macros = "*"
 libc = "0.1"
 rustc-serialize = "*"
+time = "*"
 
 [dependencies.mio]
 git = "https://github.com/carllerche/mio.git"

--- a/src/admin/messages.rs
+++ b/src/admin/messages.rs
@@ -5,7 +5,9 @@ use resp::{Format, Combinator, Parse, Parser, RespType};
 pub enum Req {
     ConfigSet(String, String),
     ConfigGet(String),
-    ClusterJoin(String)
+    ClusterJoin(String),
+    ClusterMembers,
+    ClusterStatus
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -31,6 +33,10 @@ impl Format for Msg {
                 c.array().bulk_s("config").bulk_s("get").bulk_s(&key).end(),
             Msg::Req(Req::ClusterJoin(ref ipstr)) =>
                 c.array().bulk_s("cluster").bulk_s("join").bulk_s(&ipstr).end(),
+            Msg::Req(Req::ClusterMembers) =>
+                c.array().bulk_s("cluster").bulk_s("members").end(),
+            Msg::Req(Req::ClusterStatus) =>
+                c.array().bulk_s("cluster").bulk_s("status").end(),
             Msg::Res(Res::Ok) => c.simple("ok"),
             Msg::Res(Res::Simple(ref string)) => c.simple(string),
             Msg::Res(Res::Err(ref string)) => c.error(string)
@@ -108,6 +114,12 @@ impl Parse for Msg {
 
              Parser::new(cluster_join_constructor).array()
                  .bulk(Some("cluster")).bulk(Some("join")).bulk(None).end(),
+
+             Parser::new(Box::new(|_| Ok(Msg::Req(Req::ClusterMembers)))).array()
+                 .bulk(Some("cluster")).bulk(Some("members")).end(),
+
+             Parser::new(Box::new(|_| Ok(Msg::Req(Req::ClusterStatus)))).array()
+                 .bulk(Some("cluster")).bulk(Some("status")).end(),
 
              Parser::new(Box::new(|_| Ok(Msg::Res(Res::Ok)))).simple(Some("ok")),
 

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -3,7 +3,7 @@ pub mod handler;
 pub mod event;
 mod messages;
 
-pub use self::messages::Msg;
+pub use self::messages::{Msg, Req, Res};
 pub use self::event::AdminEvent;
 pub use self::handler::AdminHandler;
 pub use self::server::AdminServer;

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -37,7 +37,9 @@ impl TcpServer for AdminServer {
                     Event::NewSock(token, addr) => handler.connect(token, addr),
                     Event::Deregister(token, addr) => handler.deregister(token, addr),
                     Event::TcpMsg(token, msg) => handler.handle_tcp_msg(token, msg),
-                    Event::ApiEvent(event) => handler.handle_event(event)
+                    Event::ApiEvent(event) => handler.handle_event(event),
+                    // Timeouts aren't used for the admin server
+                    Event::Tick => ()
                 }
             }
         }).unwrap();

--- a/src/bin/v2r2-admin.rs
+++ b/src/bin/v2r2-admin.rs
@@ -1,0 +1,163 @@
+extern crate v2r2;
+
+use std::env;
+use std::env::Args;
+use std::io;
+use std::process::exit;
+use std::io::{Result, Error, ErrorKind, Write};
+use std::str::SplitWhitespace;
+use std::net::TcpStream;
+use v2r2::resp::{Writer, Reader, Format};
+use v2r2::admin::{Req, Res, Msg};
+
+fn main() {
+    let mut args = env::args();
+    let addr = args.nth(1).unwrap();
+    let sock = TcpStream::connect(&addr[..]).unwrap();
+    if let Some(flag) = args.next() {
+        run_script(&flag, args, sock);
+    } else {
+        run_interactive(sock);
+    }
+}
+
+fn run_interactive(mut sock: TcpStream) {
+    loop {
+        prompt();
+        let mut command = String::new();
+        io::stdin().read_line(&mut command).unwrap();
+        match run(&command, &mut sock) {
+            Ok(result) => println!("{}", result),
+            Err(err) => println!("{}", err)
+        }
+    }
+}
+
+fn run_script(flag: &str, mut args: Args, mut sock: TcpStream) {
+    if flag != "-e" {
+        println!("Invalid Flag");
+        println!("{}", help());
+        exit(-1);
+    }
+    let command = args.next().unwrap_or(String::new());
+    match run(&command, &mut sock) {
+        Ok(result) => {
+            println!("{}", result);
+            exit(0);
+        }
+        Err(err) => {
+            println!("{}", err);
+            exit(-1)
+        }
+    }
+}
+
+fn run(command: &str, sock: &mut TcpStream) -> Result<String> {
+    let req = try!(parse(&command));
+    exec(req, sock)
+}
+
+fn prompt() {
+    let mut stdout = io::stdout();
+    stdout.write_all(b"v2r2> ").unwrap();
+    stdout.flush().unwrap();
+}
+
+fn parse(command: &str) -> Result<Req> {
+    let mut iter = command.split_whitespace();
+    match iter.next() {
+        Some("config") => parse_config(&mut iter),
+        Some("cluster") => parse_cluster(&mut iter),
+        Some(_) => Err(help()),
+        None => Err(help())
+    }
+}
+
+fn parse_config(iter: &mut SplitWhitespace) -> Result<Req> {
+    match iter.next() {
+        Some("set") => {
+            let args: Vec<_> = iter.collect();
+            if args.len() != 2 { return Err(help()); }
+            let key = args[0].to_string();
+            let val = args[1].to_string();
+            Ok(Req::ConfigSet(key, val))
+        },
+        Some("get") => {
+            let args: Vec<_> = iter.collect();
+            if args.len() != 1 { return Err(help()); }
+            let key = args[0].to_string();
+            Ok(Req::ConfigGet(key))
+        },
+        Some(_) => Err(help()),
+        None => Err(help())
+    }
+}
+
+fn parse_cluster(iter: &mut SplitWhitespace) -> Result<Req> {
+    match iter.next() {
+        Some("join") => {
+            let args: Vec<_> = iter.collect();
+            if args.len() != 1 { return Err(help()); }
+            let ipstr = args[0].to_string();
+            Ok(Req::ClusterJoin(ipstr))
+        },
+        Some("members") => {
+            if iter.count() != 0 { return Err(help()); }
+            Ok(Req::ClusterMembers)
+        },
+        Some("status") => {
+            if iter.count() != 0 { return Err(help()); }
+            Ok(Req::ClusterStatus)
+        },
+        Some(_) => Err(help()),
+        None => Err(help())
+    }
+}
+
+fn exec(req: Req, sock: &mut TcpStream) -> Result<String> {
+    let mut writer = Writer::new();
+    writer.format(Msg::Req(req));
+    try!(writer.write(sock));
+    let mut reader = Reader::<Msg>::new();
+    match reader.read(sock) {
+        Ok(Some(Msg::Res(response))) => {
+            match response {
+                Res::Ok => Ok("ok".to_string()),
+                Res::Simple(s) => Ok(s),
+                Res::Err(s) => Ok(s)
+            }
+        },
+        Ok(_) => {
+            // We shouldn't ever get here since we are using blocking sockets
+            Err(Error::new(ErrorKind::InvalidData, "Failed to read response from server"))
+        },
+        Err(e) => Err(e)
+    }
+}
+
+fn help() -> Error {
+    let string  =
+"Usage: v2r2-admin <IpAddress> [-e <command>]
+
+    Commands:
+        config set <Key> <Val>
+        config get <Key>
+        cluster join <ip:port>
+        cluster members
+        cluster status
+
+    Flags:
+        -e <Command>   Non-interactive mode
+
+    Config Keys:
+        node           The name of the current node
+        cluster        The name of the cluster the node is a member of
+        cluster-host   The ip:port of the cluster server listener
+        admin-host     The ip:port of the admin server listener
+
+    Examples:
+        Get the name of the current node in non-interactive mode:
+            v2r2-admin 127.0.0.1:2001 -e 'config get node'
+    ";
+    Error::new(ErrorKind::InvalidInput, string)
+}

--- a/src/bin/v2r2.rs
+++ b/src/bin/v2r2.rs
@@ -8,7 +8,7 @@ use v2r2::event_loop;
 fn main() {
     let state = State::new();
     let (state, handle1)  = event_loop::run::<ClusterServer>(state.clone());
-    let (state, handle2) = event_loop::run::<AdminServer>(state);
+    let (_, handle2) = event_loop::run::<AdminServer>(state);
     handle1.join().unwrap();
     handle2.join().unwrap();
 }

--- a/src/cluster/handler.rs
+++ b/src/cluster/handler.rs
@@ -1,6 +1,6 @@
 use resp::Writer;
 use std::io::{Error, Result, ErrorKind};
-use std::collections::{HashMap};
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use mio;
 use mio::Token;
@@ -11,13 +11,30 @@ use tcphandler::TcpHandler;
 use super::ClusterEvent;
 use super::messages::Msg;
 use admin::AdminEvent;
+use orset::ORSet;
+use membership::Member;
+use time::{SteadyTime, Duration};
 
 pub struct ClusterHandler {
     node: String,
+    addr: String,
     state: State,
     pending_joins: HashMap<Token, Token>,
-    // We only want one connection to each peer.
-    ip_map: HashMap<SocketAddr, Token>,
+
+    // Keep track of the time of the last received message on each socket
+    // We don't want just another field in `established_by_token`, because it's possible that we
+    // have a connection where we never get a message after connection and we need that to timeout
+    // as well.
+    receipts: HashMap<Token, SteadyTime>,
+
+    // We only want one connection to each peer. An established channel is one in which a Members
+    // msg is received. In order to tear down connections deterministically, we always deregister
+    // the connection from the client with the lower ip:port. `unestablished_clients` maintains the
+    // connections that this node is the connecting client of and that have not yet been
+    // established.
+    unestablished_clients: HashSet<Token>,
+    established_by_addr: HashMap<String, (bool, Token)>,
+    established_by_token: HashMap<Token, (bool, String)>,
     sender: mio::Sender<Notification>
 }
 
@@ -26,45 +43,41 @@ impl TcpHandler for ClusterHandler {
     type TcpMsg = Msg;
 
     fn new(state: State, tx: mio::Sender<Notification>) -> ClusterHandler {
-        let state2 = state.clone();
-        let members = state2.members.read().unwrap();
-        let myname = (*members).orset.name.clone();
+        let addr = {
+            let config = state.config.read().unwrap();
+            config.cluster_host.parse().unwrap()
+        };
         ClusterHandler {
-            node: myname,
+            node: state.members.local_name(),
+            addr: addr,
             state: state,
             pending_joins: HashMap::new(),
-            ip_map: HashMap::new(),
+            receipts: HashMap::new(),
+            unestablished_clients: HashSet::new(),
+            established_by_addr: HashMap::new(),
+            established_by_token: HashMap::new(),
             sender: tx
         }
     }
 
     fn connect(&mut self, token: Token, addr: SocketAddr) {
-        if let Some(_) = self.ip_map.get(&addr) {
-            // We already have a connection to this peer
-            let msg = format!("Cluster connnection for {:?} on {} already exists",
-                              addr,
-                              self.node);
-            let err = Error::new(ErrorKind::AlreadyExists, msg);
-            self.sender.send(Notification::Deregister(token, err)).unwrap();
-        } else {
-            self.ip_map.insert(addr, token);
-            self.send_members(token);
-        }
+        self.send_members(token);
+        self.receipts.insert(token, SteadyTime::now());
     }
 
-    fn deregister(&mut self, token: Token, addr: SocketAddr) {
-        if let Some(&addr_token) = self.ip_map.get(&addr) {
-            // Make sure we didn't just force the deregister in connect()
-            // due to a duplicate peer connection
-            if addr_token == token {
-                self.ip_map.remove(&addr);
-            }
+    fn deregister(&mut self, token: Token, _: SocketAddr) {
+        if let Some((_, addr)) = self.established_by_token.remove(&token) {
+            self.established_by_addr.remove(&addr);
+            self.state.members.disconnected(&addr);
+        } else {
+            self.unestablished_clients.remove(&token);
         }
         if let Some(&join_token) = self.pending_joins.get(&token) {
             let err = Error::new(ErrorKind::NotConnected, "Could not connect to server");
             self.join_err(join_token, err);
             self.pending_joins.remove(&token);
         }
+        self.receipts.remove(&token);
     }
 
     fn handle_event(&mut self, event: ClusterEvent) {
@@ -76,28 +89,145 @@ impl TcpHandler for ClusterHandler {
 
     fn handle_tcp_msg(&mut self, token: Token, msg: Msg) {
         match msg {
-            Msg::Members(orset) => {
-                let mut members = self.state.members.write().unwrap();
-                {
-                    let myname = &mut (*members).orset.name;
-                    println!("Got Msg::Members for {:?} from {:?} ", myname, orset.name);
-                }
-                (*members).orset.join_state(orset);
-                if let Some(&join_token) = self.pending_joins.get(&token) {
-                    println!("Ahah pending join!!!");
-                    self.join_success(join_token);
-                    self.pending_joins.remove(&token);
-                }
-                // Check to see if there are any members that we don't have connections to
-                // Also should do this in a 'tick' periodically in case of
-                // disconnections/partitions/errors etc...
-                // self.check_connecions();
+            Msg::Members(addr, orset) => {
+                println!("Got Msg::Members for {:?} from {:?} ", self.node, orset.name);
+                self.maybe_establish_connection(token, addr);
+                self.join_members(orset, token);
+                self.check_connections();
+            },
+            Ping => {
+                self.receipts.insert(token, SteadyTime::now());
             }
         }
     }
+
+    fn tick(&mut self) {
+        self.check_liveness();
+        self.send_pings();
+        self.check_connections();
+    }
+}
+
+fn connected_ips(established: &HashMap<String, (bool, Token)>) -> HashSet<String> {
+    established.iter().map(|(ref addr, _)| addr.to_string()).collect()
 }
 
 impl ClusterHandler {
+
+    /// The current tick comes in at one second intervals, meaning each node should send a `Ping`
+    /// every second. If we haven't received a Ping within 5 seconds, the connection should be
+    /// considered dead and closed.
+    // TODO: As an optimization, we should only check connections that we know will expire in the
+    // next tick.
+    // TODO: need a good way to test this: Either network partition, or test code that doesn't send
+    // Pings
+    fn check_liveness(&mut self) {
+        let now = SteadyTime::now();
+        let to_remove =
+            self.receipts.iter().filter(|&(&token, &time)| now - time > Duration::seconds(5));
+        for (&token, _) in to_remove {
+            let msg = format!("Cluster connection for {:?} timed out", token);
+            let err = Error::new(ErrorKind::TimedOut, msg);
+            self.sender.send(Notification::Deregister(token, err)).unwrap();
+        }
+    }
+
+    fn send_pings(&self) {
+        let msg = Writer::encode(Msg::Ping);
+        for (&token, _) in self.receipts.iter() {
+            self.sender.send(Notification::WireMsg(token, msg.clone())).unwrap();
+        }
+    }
+
+
+    fn maybe_establish_connection(&mut self, token: Token, addr: String) {
+        let maybe_token = self.pick_token_to_deregister(token, &addr);
+        match maybe_token {
+            Some(deregister_token) => {
+                let msg = format!("Peer {:?} already connected", addr);
+                let err = Error::new(ErrorKind::Other, msg);
+                if deregister_token == token {
+                    // Deregister the incoming connection
+                    self.sender.send(Notification::Deregister(token, err)).unwrap();
+                } else {
+                    // Deregister the already established connection
+                    // Cleanup connection here and not in deregister callback, because we don't want
+                    // to call self.state.members.disconnected();
+                    self.established_by_token.remove(&deregister_token);
+                    self.established_by_addr.remove(&addr);
+                    self.sender.send(Notification::Deregister(deregister_token, err)).unwrap();
+                    self.establish_connection(token, addr);
+                }
+            },
+            None => self.establish_connection(token, addr)
+        }
+    }
+
+    // This function wouldn't be necessary if the damn borrow checker didn't match lifetimes to
+    // scope.
+    // See 'Borrow checker improvements here: http://blog.rust-lang.org/2015/08/14/Next-year.html
+    fn pick_token_to_deregister(&self, token: Token, addr: &String) -> Option<Token>{
+        if let Some(&(ref is_client, ref established_token)) = self.established_by_addr.get(addr) {
+            if (*is_client && self.addr < *addr) || (!*is_client && self.addr > *addr) {
+                Some(*established_token)
+            } else {
+                Some(token)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn establish_connection(&mut self, token: Token, addr: String) {
+        let is_client = self.unestablished_clients.remove(&token);
+        self.established_by_addr.insert(addr.clone(), (is_client, token));
+        self.established_by_token.insert(token, (is_client, addr));
+    }
+
+    // TODO: Where do we check the validity of ip addresses and report errors? Here they are just
+    // excluded via the flat_map().
+    /// Ensure connections are correct based on membership state
+    fn check_connections(&mut self) {
+        let addrs: Vec<SocketAddr> = self.to_connect().iter().flat_map(|ip| ip.parse()).collect();
+        for addr in addrs {
+            self.init_connect(addr);
+        }
+
+        let addrs: Vec<String> = self.to_disconnect().iter().cloned().map(|ip| ip).collect();
+        for addr in addrs {
+            if let Some(&(_, ref token)) = self.established_by_addr.get(&addr) {
+                let msg = format!("{:?} no longer part of cluster membership", addr);
+                let err = Error::new(ErrorKind::Other, msg);
+                self.sender.send(Notification::Deregister(*token, err)).unwrap();
+            }
+        }
+
+        let addrs: Vec<String> = self.to_membership_connect().iter().cloned().map(|ip| ip).collect();
+        for addr in addrs {
+            self.state.members.connected(&addr)
+        }
+    }
+
+    /// IPs that the cluster server needs to establish connections with
+    fn to_connect(&self) -> HashSet<String> {
+        let connected = connected_ips(&self.established_by_addr);
+        self.state.members.get_ips().difference(&connected)
+            .filter(|&ip| *ip != self.addr).cloned().collect()
+    }
+
+    /// IPs that the cluster server needs to disconnect from
+    fn to_disconnect(&self) -> HashSet<String> {
+        let connected = connected_ips(&self.established_by_addr);
+        connected.difference(&self.state.members.get_ips()).cloned().collect()
+    }
+
+    /// IPs that are connected to the cluster server that the membership system doesn't know
+    /// about yet.
+    fn to_membership_connect(&self) -> HashSet<String> {
+        let connected = connected_ips(&self.established_by_addr);
+        connected.difference(&self.state.members.get_connected_ips()).cloned().collect()
+    }
+
     fn join_err(&self, token: Token, err: Error) {
         let reply =
             Event::ApiEvent(AdminEvent::JoinReply {token: token, reply: Err(err)});
@@ -124,11 +254,23 @@ impl ClusterHandler {
         }
     }
 
+    fn join_members(&mut self, orset: ORSet<Member>, token: Token) {
+        self.state.members.join(orset);
+        if let Some(&join_token) = self.pending_joins.get(&token) {
+            self.join_success(join_token);
+            self.pending_joins.remove(&token);
+        }
+    }
+
+    fn init_connect(&mut self, addr: SocketAddr) {
+        let token = self.state.next_token();
+        self.sender.send(Notification::Connect(token, addr)).unwrap();
+    }
+
     fn send_members(&mut self, token: Token) {
         println!("Sending members for {}", self.node);
-        let members = self.state.members.read().unwrap();
-        let orset = (*members).orset.clone();
-        let msg = Writer::encode(Msg::Members(orset));
+        let orset = self.state.members.get_orset();
+        let msg = Writer::encode(Msg::Members(self.addr.clone(), orset));
         self.sender.send(Notification::WireMsg(token, msg)).unwrap();
     }
 }

--- a/src/cluster/messages.rs
+++ b/src/cluster/messages.rs
@@ -7,7 +7,8 @@ use std::io::{Error, ErrorKind};
 
 #[derive(Debug, RustcEncodable, RustcDecodable)]
 pub enum Msg {
-    Members(ORSet<Member>)
+    Members(String, ORSet<Member>),
+    Ping
 }
 
 // This just wraps a message pack encoded string inside a resp bulk string

--- a/src/cluster/server.rs
+++ b/src/cluster/server.rs
@@ -35,6 +35,7 @@ impl TcpServer for ClusterServer {
                     Event::NewSock(token, addr) => handler.connect(token, addr),
                     Event::Deregister(token, addr) => handler.deregister(token, addr),
                     Event::TcpMsg(token, msg) => handler.handle_tcp_msg(token, msg),
+                    Event::Tick => handler.tick(),
                     Event::ApiEvent(event) => handler.handle_event(event)
                 }
             }
@@ -68,5 +69,9 @@ impl TcpServer for ClusterServer {
 
     fn handle_tcp_msg(&self, token: Token, msg: Msg) {
         self.sender.send(Event::TcpMsg(token, msg)).unwrap();
+    }
+
+    fn tick(&self) {
+        self.sender.send(Event::Tick).unwrap();
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,5 +9,6 @@ pub enum Event<T: Send, P: Parse> {
     NewSock(Token, SocketAddr),
     Deregister(Token, SocketAddr),
     TcpMsg(Token, P),
+    Tick,
     ApiEvent(T)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,17 @@ extern crate serde;
 extern crate mio;
 extern crate msgpack;
 extern crate rustc_serialize;
+extern crate time;
 
 pub mod config;
 pub mod event_loop;
 pub mod admin;
 pub mod cluster;
 pub mod state;
+pub mod resp;
 
 mod event;
 mod orset;
-mod resp;
 mod tcpserver;
 mod tcphandler;
 mod membership;

--- a/src/orset.rs
+++ b/src/orset.rs
@@ -141,7 +141,7 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
         return mutated
     }
 
-    fn contains(&self, element: &T) -> bool {
+    pub fn contains(&self, element: &T) -> bool {
         if let Some(adds) = self.adds.get(element) {
             if adds.is_empty() {
                 false
@@ -153,7 +153,7 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
         }
     }
 
-    fn elements(&self) -> Vec<T> {
+    pub fn elements(&self) -> Vec<T> {
         self.adds.iter().fold(Vec::new(), |mut acc, (elem, dots)| {
             if dots.is_empty() {
                 acc

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -17,6 +17,10 @@ impl Writer {
         }
     }
 
+    pub fn format<T: Format>(&mut self, msg: T) {
+        self.data = Writer::encode(msg);
+    }
+
     pub fn encode<T: Format>(msg: T) -> Vec<Vec<u8>>{
         msg.format().value()
     }
@@ -644,7 +648,7 @@ mod tests {
         fn parsers() -> Vec<Parser<Msg>> {
             // The constructor takes the chain of matched types from parsing
             // and constructs a Msg::ClusterSetName(...)
-            let cluster_set_name_constructor = Box::new(|types: &Vec<RespType>| {
+            let cluster_set_name_constructor = Box::new(|types: &mut Vec<RespType>| {
                 if let RespType::Bulk(ref val) = types[3] {
                     match String::from_utf8(val.clone()) {
                         Ok(string) => return Ok(Msg::ClusterSetName(string)),

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,7 +11,7 @@ use mio::Token;
 
 pub struct State {
     pub config: Arc<RwLock<Config>>,
-    pub members: Arc<RwLock<Members>>,
+    pub members: Members,
     pub cluster_tx: Option<Sender<Event<ClusterEvent, cluster::Msg>>>,
     pub admin_tx: Option<Sender<Event<AdminEvent, admin::Msg>>>,
     token: Arc<Mutex<Token>>
@@ -26,7 +26,7 @@ impl State {
                                    config.cluster_host.clone());
         State {
             config: Arc::new(RwLock::new(config)),
-            members: Arc::new(RwLock::new(members)),
+            members: members,
             cluster_tx: None,
             admin_tx: None,
             token: Arc::new(Mutex::new(Token(0)))

--- a/src/tcphandler.rs
+++ b/src/tcphandler.rs
@@ -13,4 +13,5 @@ pub trait TcpHandler {
     fn deregister(&mut self, token: Token, addr: SocketAddr) {}
     fn handle_tcp_msg(&mut self, token: Token, msg: Self::TcpMsg);
     fn handle_event(&mut self, Self::Event);
+    fn tick(&mut self) {}
 }

--- a/src/tcpserver.rs
+++ b/src/tcpserver.rs
@@ -14,4 +14,5 @@ pub trait TcpServer {
     fn new_sock(&self, token: Token, addr: SocketAddr);
     fn handle_tcp_msg(&self, token: Token, msg: Self::TcpMsg);
     fn deregister(&self, token: Token, addr: SocketAddr);
+    fn tick(&self) {}
 }


### PR DESCRIPTION
The admin client communicates over tcp using blocking sockets and the
resp protocol, and talks to the admin port of v2r2. It provides config
get/set for the connected node as well as membership and cluster status.
By default the admin-cli runs as an interactive shell. It can run a
single command via the `-e` flag. This is useful for shell scripting.

After launching a development cluster with `make launch`, an admin
client connected to the first node (dev1) can be run via:
`cargo run --bin v2r2-admin -- 127.0.0.1:2001`. It's handy to wrap this
command using `rlwrap` so that you get typical readline support.

Admin status and membership are tracked as part of the global `State`
struct present in all handlers.

A 1 second tick was added to event loops and results in the periodic
firing of the `tick` callback in server handlers. Currently it is only
used in the cluster server and serves the following purposes:
- Connect to peers that are members of the cluster, but not currently
  connected (auto-reconnect)
- Remove connected peers that are no longer members of the cluster
- Inform the membership system of connected/disconnected peers so that
  it can update the global state used by the admin server for
  reporting.
- Send `Ping` messages to peers to detect liveness (heartbeating)
