### PR TITLE
Add an API for VR along with a CLI client

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
  "node_name": "node1",
  "cluster_name":"cluster1",
  "admin_host": "127.0.0.1:5000",
- "cluster_host": "127.0.0.1:5001"
+ "cluster_host": "127.0.0.1:5001",
+ "vr_api_host": "127.0.0.1:5002"
 }

--- a/src/bin/devconfig.rs
+++ b/src/bin/devconfig.rs
@@ -11,6 +11,7 @@ fn main() {
 
     let cluster_port = n.to_string();
     let admin_port = (n+1).to_string();
+    let vr_api_port = (n+2).to_string();
 
     let mut cluster_host = "127.0.0.1:".to_string();
     cluster_host.push_str(&cluster_port);
@@ -18,11 +19,15 @@ fn main() {
     let mut admin_host = "127.0.0.1:".to_string();
     admin_host.push_str(&admin_port);
 
+    let mut vr_api_host = "127.0.0.1:".to_string();
+    vr_api_host.push_str(&vr_api_port);
+
     let config = Config {
         node_name: name,
         cluster_name: "dev-cluster".to_string(),
         cluster_host: cluster_host,
-        admin_host: admin_host
+        admin_host: admin_host,
+        vr_api_host: vr_api_host
     };
     config.write_path("config.json");
 }

--- a/src/bin/v2r2-admin.rs
+++ b/src/bin/v2r2-admin.rs
@@ -59,7 +59,7 @@ fn run(command: &str, sock: &mut TcpStream) -> Result<String> {
 
 fn prompt() {
     let mut stdout = io::stdout();
-    stdout.write_all(b"v2r2> ").unwrap();
+    stdout.write_all(b"v2r2-admin> ").unwrap();
     stdout.flush().unwrap();
 }
 

--- a/src/bin/v2r2-cli-client.rs
+++ b/src/bin/v2r2-cli-client.rs
@@ -1,0 +1,216 @@
+extern crate v2r2;
+
+use std::env;
+use std::env::Args;
+use std::io;
+use std::process::exit;
+use std::io::{Result, Error, ErrorKind, Write};
+use std::str::{SplitWhitespace, FromStr};
+use std::net::TcpStream;
+use v2r2::resp::{Writer, Reader, Format};
+use v2r2::vr_api::{Req, Rsp};
+use v2r2::element::{Version, ElementType};
+
+fn main() {
+    let mut args = env::args();
+    let addr = args.nth(1).unwrap();
+    let sock = TcpStream::connect(&addr[..]).unwrap();
+    if let Some(flag) = args.next() {
+        run_script(&flag, args, sock);
+    } else {
+        run_interactive(sock);
+    }
+}
+
+fn run_interactive(mut sock: TcpStream) {
+    loop {
+        prompt();
+        let mut command = String::new();
+        io::stdin().read_line(&mut command).unwrap();
+        match run(&command, &mut sock) {
+            Ok(result) => println!("{}", result),
+            Err(err) => println!("{}", err)
+        }
+    }
+}
+
+fn run_script(flag: &str, mut args: Args, mut sock: TcpStream) {
+    if flag != "-e" {
+        println!("Invalid Flag");
+        println!("{}", help());
+        exit(-1);
+    }
+    let command = args.next().unwrap_or(String::new());
+    match run(&command, &mut sock) {
+        Ok(result) => {
+            println!("{}", result);
+            exit(0);
+        }
+        Err(err) => {
+            println!("{}", err);
+            exit(-1)
+        }
+    }
+}
+
+fn run(command: &str, sock: &mut TcpStream) -> Result<String> {
+    let req = try!(parse(&command));
+    exec(req, sock)
+}
+
+fn prompt() {
+    let mut stdout = io::stdout();
+    stdout.write_all(b"v2r2> ").unwrap();
+    stdout.flush().unwrap();
+}
+
+fn parse(command: &str) -> Result<Req> {
+    let mut iter = command.split_whitespace();
+    match iter.next() {
+        Some("create") => parse_create(&mut iter),
+        Some("put") => parse_put(&mut iter),
+        Some("delete") => parse_delete(&mut iter),
+        Some("get") => parse_get(&mut iter),
+        Some("list") => parse_list(&mut iter),
+        Some(_) => Err(help()),
+        None => Err(help())
+    }
+}
+
+fn parse_create(iter: &mut SplitWhitespace) -> Result<Req> {
+    match iter.next() {
+        Some(str_type) => match ElementType::from_str(str_type) {
+            Ok(ty) => {
+                let args: Vec<_> = iter.collect();
+                if args.len() != 1 { return Err(help()); }
+                let path = args[0].to_string();
+                Ok(Req::Create {path: path, ty: ty})
+            },
+            Err(_) => Err(help())
+        },
+        None => Err(help())
+    }
+}
+
+fn parse_put(iter: &mut SplitWhitespace) -> Result<Req> {
+    let path = try!(iter.next().ok_or(help()));
+    let path = path.to_string();
+    let data = try!(iter.next().ok_or(help()));
+    let data = data.bytes().collect();
+    match iter.next() {
+        Some(str_tag) => {
+            match Version::from_str(str_tag) {
+                Ok(tag) => Ok(Req::Put {path: path, data: data, cas_tag: Some(tag)}),
+                Err(_) => {
+                    println!("Invalid Version for CAS. Must be of format Epoch:VSN:LSN");
+                    Err(help())
+                }
+            }
+        },
+        None => Ok(Req::Put {path: path, data: data, cas_tag: None})
+    }
+}
+
+fn parse_delete(iter: &mut SplitWhitespace) -> Result<Req> {
+    let path = try!(iter.next().ok_or(help()));
+    let path = path.to_string();
+    match iter.next() {
+        Some(str_tag) => {
+            match Version::from_str(str_tag) {
+                Ok(tag) => Ok(Req::Delete {path: path, cas_tag: Some(tag)}),
+                Err(_) => {
+                    println!("Invalid Version for CAS. Must be of format Epoch:VSN:LSN");
+                    Err(help())
+                }
+            }
+        },
+        None => Ok(Req::Delete {path: path, cas_tag: None})
+    }
+}
+
+fn parse_get(iter: &mut SplitWhitespace) -> Result<Req> {
+    let path = try!(iter.next().ok_or(help()));
+    let path = path.to_string();
+    let rv = match iter.next() {
+        Some("cas") => Ok(Req::Get {path: path, cas: true}),
+        Some(_) => Err(help()),
+        None => Ok(Req::Get {path: path, cas: false})
+    };
+    if iter.count() != 0 { return Err(help()); }
+    rv
+}
+
+fn parse_list(iter: &mut SplitWhitespace) -> Result<Req> {
+    let path = try!(iter.next().ok_or(help()));
+    let path = path.to_string();
+    if iter.count() != 0 { return Err(help()); }
+    Ok(Req::List {path: path})
+}
+
+fn exec(msg: Req, sock: &mut TcpStream) -> Result<String> {
+    let mut writer = Writer::new();
+    writer.format(msg);
+    try!(writer.write(sock));
+    let mut reader = Reader::<Rsp>::new();
+    loop {
+        match reader.read(sock) {
+            Ok(Some(response)) => {
+                return match response {
+                    Rsp::Ok => Ok("ok".to_string()),
+                    Rsp::Element {data, cas_tag} => {
+                        // TODO: The data may not always be utf8
+                        let string = String::from_utf8(data).unwrap();
+                        match cas_tag {
+                            Some(tag) => {
+                                Ok(format!("CAS: {}\n{}", tag.to_string(), string))
+                            },
+                            None => Ok(string)
+                        }
+                    },
+                    Rsp::KeyList {keys} => {
+                        Ok(keys.iter().fold(String::new(), |mut acc, k| {
+                            acc.push_str(k);
+                            acc.push_str("\n");
+                            acc
+                        }))
+                    },
+                    Rsp::Error {msg: s} => Ok(s)
+                }
+            },
+            Ok(None) => (),
+            Err(e) => return Err(e)
+        }
+    }
+}
+
+fn help() -> Error {
+    let string  =
+"Usage: v2r2-cli-client <IpAddress> [-e <command>]
+
+    Commands:
+        create <Element Type> <Path>
+        put <Path> <Data> [CAS Version]
+        delete <Path> [CAS Version]
+        get <Path> [\"CAS\"]
+        list <Path>
+
+    Flags:
+        -e <Command>   Non-interactive mode
+
+    Element Types:
+        binary
+        list
+        queue
+        set
+
+    Examples:
+        Create a node /foo
+            v2r2> create binary /foo
+        Put data to /foo
+            v2r2> put /foo newdata
+        Put data only if the version matches existing data
+            v2r2> put /foo somedata 0:0:2
+
+    ";
+    Error::new(ErrorKind::InvalidInput, string)
+}

--- a/src/bin/v2r2.rs
+++ b/src/bin/v2r2.rs
@@ -5,6 +5,7 @@ use v2r2::state::State;
 use v2r2::admin;
 use v2r2::admin::AdminMsg;
 use v2r2::cluster;
+use v2r2::vr_api;
 
 fn main() {
     let state = State::new();
@@ -14,12 +15,12 @@ fn main() {
     let (admin_tx, cluster_rx) = channel::<AdminMsg>();
 
     let handles1 = cluster::server::run(state.clone(), cluster_tx, cluster_rx);
-    let handles2 = admin::server::run(state, admin_tx, admin_rx);
+    let handles2 = admin::server::run(state.clone(), admin_tx, admin_rx);
+    let handles3 = vr_api::server::run(state);
 
-    for h in handles1 {
-        h.join().unwrap();
-    }
-    for h in handles2 {
-        h.join().unwrap();
+    for l in vec![handles1, handles2, handles3] {
+        for h in l {
+            h.join().unwrap();
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub cluster_name: String,
     pub cluster_host: String, // ip:port or dns name used on cluster network
     pub admin_host: String, // ip:port or dns name used for admin interface
+    pub vr_api_host: String
 }
 
 impl Config {
@@ -42,6 +43,7 @@ impl Config {
             "cluster" => Ok(self.cluster_name.clone()),
             "cluster-host" => Ok(self.cluster_host.clone()),
             "admin-host" => Ok(self.admin_host.clone()),
+            "vr-api-host" => Ok(self.vr_api_host.clone()),
             _ => Err(self.err(key))
         }
     }
@@ -63,6 +65,8 @@ impl Config {
             },
             "admin-host" => Err(Error::new(ErrorKind::InvalidInput,
                                           "admin-host is not configurable at runtime")),
+            "vr-api-host" => Err(Error::new(ErrorKind::InvalidInput,
+                                          "vr-api-host is not configurable at runtime")),
             _ => Err(self.err(key))
         }
     }
@@ -85,7 +89,8 @@ mod tests {
             node_name: "node1".to_string(),
             cluster_name: "cluster1".to_string(),
             cluster_host: "192.168.1.1:5000".to_string(),
-            admin_host: "127.0.0.1:5000".to_string()
+            admin_host: "127.0.0.1:5001".to_string(),
+            vr_api_host: "127.0.0.1:5002".to_string()
         };
 
         config.write_path(path);

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,0 +1,63 @@
+use std::str::FromStr;
+use std::string::ToString;
+
+#[derive(Debug, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+pub enum ElementType {
+    Binary,
+    List,
+    Set,
+    Queue
+}
+
+impl FromStr for ElementType {
+    type Err = ();
+    fn from_str(string: &str) -> Result<ElementType, ()> {
+        match string {
+            "binary" => Ok(ElementType::Binary),
+            "list"  => Ok(ElementType::List),
+            "set" => Ok(ElementType::Set),
+            "queue" => Ok(ElementType::Queue),
+            _ => Err(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+pub struct Version {
+    epoch: usize,
+    vsn: usize,
+    lsn: usize,
+}
+
+impl Version {
+    pub fn new() -> Version {
+        Version {
+            epoch: 0,
+            vsn: 0,
+            lsn: 0
+        }
+    }
+
+    pub fn inc(&mut self) -> Version {
+        self.lsn = self.lsn + 1;
+        self.clone()
+    }
+}
+
+impl FromStr for Version {
+    type Err = ();
+    fn from_str(string: &str) -> Result<Version, ()> {
+        let v: Vec<&str> = string.split(':').collect();
+        if v.len() != 3 { return Err(()); }
+        let epoch = try!(usize::from_str(v[0]).or(Err(())));
+        let vsn = try!(usize::from_str(v[1]).or(Err(())));
+        let lsn = try!(usize::from_str(v[2]).or(Err(())));
+        Ok(Version { epoch: epoch, vsn: vsn, lsn: lsn })
+    }
+}
+
+impl ToString for Version {
+    fn to_string(&self) -> String {
+        format!("{}:{}:{}", self.epoch, self.vsn, self.lsn)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(custom_derive, plugin)]
 #![plugin(serde_macros)]
 #![feature(mpsc_select)]
+#![feature(btree_range, collections_bound)]
 
 #[cfg(test)]
 extern crate quickcheck;
@@ -21,6 +22,8 @@ pub mod admin;
 pub mod cluster;
 pub mod state;
 pub mod resp;
+pub mod vr_api;
+pub mod element;
 
 mod event;
 mod orset;

--- a/src/vr_api/backend.rs
+++ b/src/vr_api/backend.rs
@@ -1,0 +1,212 @@
+use std::path::Path;
+use std::collections::BTreeMap;
+use std::collections::Bound::{Excluded, Unbounded};
+use super::messages::{Req, Rsp};
+use element::{ElementType, Version};
+
+// TODO: Parameterize data based on element type (i.e. don't ignore it)
+struct Element {
+    version: Version,
+    ty: ElementType,
+    data: Vec<u8>
+}
+
+pub struct VrBackend {
+    tree: BTreeMap<String, Element>,
+}
+
+impl VrBackend {
+    pub fn new() -> VrBackend {
+        VrBackend {
+            tree: BTreeMap::new(),
+        }
+    }
+
+    pub fn call(&mut self, version: Version, msg: Req) -> Rsp {
+        let resp = match msg {
+             Req::Create {path, ty} => self.create_element(version, path, ty),
+             Req::Put {path, data, cas_tag} => self.put(version, path, data, cas_tag),
+             Req::Delete {path, cas_tag} => self.delete(version, path, cas_tag),
+             Req::Get {path, cas} => self.get(path, cas),
+             Req::List {path} => self.list(path)
+        };
+        match resp {
+            Ok(msg) => msg,
+            Err(msg) => msg
+        }
+    }
+
+    fn create_element(&mut self, version: Version, path: String, ty: ElementType) -> Result<Rsp, Rsp> {
+        try!(self.parent_exists(&path));
+        try!(self.does_not_exist(&path));
+        let el = Element { version: version, ty: ty, data: Vec::new()};
+        self.tree.insert(path, el);
+        Ok(Rsp::Ok)
+    }
+
+    fn get(&self, path: String, cas: bool) -> Result<Rsp, Rsp> {
+        if let Some(element) = self.tree.get(&path) {
+            if cas {
+                return Ok(Rsp::Element {data: element.data.clone(),
+                                        cas_tag: Some(element.version.clone())})
+            }
+            Ok(Rsp::Element {data: element.data.clone(), cas_tag: None})
+        } else {
+            Err(Rsp::Error {msg: format!("No element found for {:?}", path)})
+        }
+    }
+
+    fn list(&self, path: String) -> Result<Rsp, Rsp> {
+        if &path != "/" && !self.tree.contains_key(&path) {
+            return Err(Rsp::Error {msg: format!("{} does not exist", path)});
+        }
+        let mut keys = Vec::new();
+        for (ref key, _) in self.tree.range::<String, String>(Excluded(&path), Unbounded) {
+            keys.push((*key).clone());
+        }
+        Ok(Rsp::KeyList {keys: keys})
+    }
+
+    fn delete(&mut self, version: Version, path: String, cas_tag: Option<Version>)
+        -> Result<Rsp, Rsp> {
+
+        if let Some(element) = self.tree.remove(&path) {
+            match cas_tag {
+                Some(tag) => {
+                    if element.version == tag {
+                        Ok(Rsp::Ok)
+                    } else {
+                        self.tree.insert(path.clone(), element);
+                        Err(Rsp::Error {msg: format!("Element {} does not exist", path)})
+                    }
+                },
+                None => Ok(Rsp::Ok)
+            }
+        } else {
+            Err(Rsp::Error {msg: format!("Element {} does not exist", path)})
+        }
+    }
+
+    fn put(&mut self, version: Version, path: String, data: Vec<u8>, cas_tag: Option<Version>)
+        -> Result<Rsp, Rsp> {
+
+        match self.tree.get_mut(&path) {
+            None => Err(Rsp::Error {msg: format!("Element {} does not exist", path)}),
+            Some(element) => match cas_tag {
+                Some(tag) => {
+                    if element.version == tag {
+                        VrBackend::put_always(element, version, data)
+                    } else {
+                        Err(Rsp::Error {msg: format!("CAS failed. Version = {:?}, Expected  {:?}",
+                                                     element.version, tag)})
+                    }
+                },
+                None => {
+                    VrBackend::put_always(element, version, data)
+                }
+            }
+        }
+    }
+
+    // TODO: Try to convert data to it's proper type based on element.ty
+    fn put_always(element: &mut Element, version: Version, data: Vec<u8>) -> Result<Rsp, Rsp> {
+        (*element).version = version;
+        (*element).data = data;
+        Ok(Rsp::Ok)
+    }
+
+    fn does_not_exist(&self, path: &str) -> Result<(), Rsp> {
+        if self.tree.contains_key(path) {
+            Err(Rsp::Error {msg: format!("Element {:?} already exists", path)})
+        } else {
+            Ok(())
+        }
+    }
+
+    fn parent_exists(&self, path: &str) -> Result<(), Rsp> {
+        let path = Path::new(path);
+        if let Some(parent) = path.parent() {
+            // We don't have an explicit root
+            if parent == Path::new("/") { return Ok(()) };
+            let parent = parent.to_str().unwrap();
+            if self.tree.contains_key(parent) {
+                Ok(())
+            } else {
+                Err(Rsp::Error {msg: format!("Parent element {} does not exist", parent)})
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vr_api::messages::*;
+    use element::{ElementType, Version};
+
+    fn assert_ok(res: Result<Rsp, Rsp>) {
+        match res {
+            Ok(val) => assert_eq!(val, Rsp::Ok),
+            Err(e) => {
+                println!("assert_ok failed with error: {:?}", e);
+                assert!(false)
+            }
+        }
+    }
+
+    fn assert_err(res: Result<Rsp, Rsp>) {
+        match res {
+            Ok(_) => assert!(false),
+            Err(_) => assert!(true)
+        }
+    }
+
+    #[test]
+    fn create_element() {
+        let mut backend = VrBackend::new();
+        let mut version = Version::new();
+        assert_ok(backend.create_element(version.inc(), "/foo".to_string(), ElementType::Binary));
+        assert_err(backend.create_element(version.inc(), "/foo/bar/wat".to_string(), ElementType::Binary));
+        assert_err(backend.create_element(version.inc(), "relative_path".to_string(), ElementType::Binary));
+        assert_err(backend.create_element(version.inc(), "rel/path".to_string(), ElementType::Binary));
+        assert_ok(backend.create_element(version.inc(), "/foo/bar".to_string(), ElementType::Binary));
+    }
+
+    #[test]
+    fn put() {
+        let mut backend = VrBackend::new();
+        let mut version = Version::new();
+        assert_err(backend.put(version.inc(), "/foo".to_string(), Vec::new(), None));
+        assert_err(backend.put(version.inc(),"/foo".to_string(), Vec::new(), Some(version.clone())));
+        assert_ok(backend.create_element(version.inc(), "/foo".to_string(), ElementType::Binary));
+        assert_ok(backend.put(version.inc(), "/foo".to_string(), vec![5,6,7], None));
+        assert_err(backend.put(version.inc(), "/foo".to_string(), vec![8,9,10], Some(version.clone())));
+        assert_err(backend.put(version.inc(), "/foo".to_string(), vec![8,9,10], Some(version.inc())));
+    }
+
+    #[test]
+    fn get() {
+        let mut backend = VrBackend::new();
+        let mut version = Version::new();
+        assert_err(backend.get("/foo".to_string(), false));
+        assert_err(backend.get("/foo".to_string(), true));
+        assert_ok(backend.create_element(version.inc(), "/foo".to_string(), ElementType::Binary));
+        let elem = backend.get("/foo".to_string(), false);
+        if let Ok(Rsp::Element {cas_tag, ..}) = elem {
+            assert_eq!(cas_tag, None);
+        } else {
+            assert!(false);
+        }
+        let elem = backend.get("/foo".to_string(), true);
+        if let Ok(Rsp::Element {cas_tag, ..}) = elem {
+            assert_eq!(cas_tag, Some(Version::new().inc()));
+        } else {
+            assert!(false);
+        }
+    }
+
+
+}

--- a/src/vr_api/handler.rs
+++ b/src/vr_api/handler.rs
@@ -1,0 +1,99 @@
+use resp::Writer;
+use event_loop::Notification;
+use mio;
+use mio::Token;
+use state::State;
+use tcphandler::TcpHandler;
+use super::messages::{Req, Rsp};
+use event::Event;
+use std::error;
+use std::sync::mpsc::{channel, Sender, Receiver};
+use rustc_serialize::Encodable;
+use super::mock_vr::{VrReq, VrResp};
+
+pub struct VrApiHandler {
+    node: String,
+    state: State,
+    vr_tx: Sender<VrReq>,
+    vr_rx: Option<Receiver<VrResp>>,
+    event_loop_tx: Option<mio::Sender<Notification>>,
+    event_loop_rx: Option<Receiver<Event<Req>>>,
+    // To be given away to the event loop so it can send us messages
+    event_loop_sender: Sender<Event<Req>>
+}
+
+impl TcpHandler for VrApiHandler {
+    type TcpMsg = Req;
+
+    fn set_event_loop_tx(&mut self, tx: mio::Sender<Notification>) {
+        self.event_loop_tx = Some(tx);
+    }
+
+    fn event_loop_sender(&self) -> Sender<Event<Req>> {
+        self.event_loop_sender.clone()
+    }
+
+    fn host(state: &State) -> String {
+        let config = state.config.read().unwrap();
+        config.vr_api_host.clone()
+    }
+
+    // Main handler loop
+    fn recv_loop(&mut self) {
+        let event_loop_rx = self.event_loop_rx.take().unwrap();
+        let vr_rx = self.vr_rx.take().unwrap();
+        loop {
+            select! {
+                msg = vr_rx.recv() => self.handle_vr_resp(msg.unwrap()),
+                event = event_loop_rx.recv() => self.handle_event(event.unwrap())
+            }
+        }
+    }
+}
+
+impl VrApiHandler {
+    pub fn new(state: State, vr_tx: Sender<VrReq>, vr_rx: Receiver<VrResp> ) -> VrApiHandler {
+        let (tx, rx) = channel();
+        VrApiHandler {
+            node: state.members.local_name(),
+            state: state,
+            vr_tx: vr_tx,
+            vr_rx: Some(vr_rx),
+            event_loop_tx: None,
+            event_loop_rx: Some(rx),
+            event_loop_sender: tx
+        }
+    }
+
+    fn handle_event(&mut self, event: Event<Req>) {
+        match event {
+            Event::TcpMsg(token, msg) => self.handle_tcp_msg(token, msg),
+            _ => ()
+        }
+    }
+
+    fn handle_tcp_msg(&mut self, token: Token, msg: Req) {
+        match msg {
+            Req::Create {..} => self.vr_write(token, msg),
+            Req::Put {..} => self.vr_write(token, msg),
+            Req::Delete {..} => self.vr_write(token, msg),
+            Req::Get {..} => self.vr_read(token, msg),
+            Req::List {..} => self.vr_read(token, msg)
+        };
+    }
+
+    fn handle_vr_resp(&self, resp: VrResp) {
+        let VrResp(token, msg) = resp;
+        let msg = Writer::encode(msg);
+        self.event_loop_tx.as_ref().unwrap().send(Notification::WireMsg(token, msg)).unwrap();
+    }
+
+    fn vr_write(&self, token: Token, msg: Req) {
+        self.vr_tx.send(VrReq::Write(token, msg)).unwrap();
+    }
+
+    fn vr_read(&self, token: Token, msg: Req) {
+        self.vr_tx.send(VrReq::Read(token, msg)).unwrap();
+    }
+}
+

--- a/src/vr_api/messages.rs
+++ b/src/vr_api/messages.rs
@@ -1,0 +1,74 @@
+use resp::{Format, Combinator, Parse, Parser, RespType};
+use rustc_serialize::Encodable;
+use msgpack::{Encoder, from_msgpack};
+use std::io::{Error, ErrorKind};
+use element::{ElementType, Version};
+
+#[derive(Debug, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+pub enum Req {
+    Create {path: String, ty: ElementType},
+    Put {path: String, data: Vec<u8>, cas_tag: Option<Version>},
+    Get {path: String, cas: bool},
+    Delete {path: String, cas_tag: Option<Version>},
+    List {path: String}
+}
+
+#[derive(Debug, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+pub enum Rsp {
+    Element {data: Vec<u8>, cas_tag: Option<Version>},
+    KeyList {keys: Vec<String>},
+    Ok,
+    // TODO: Should probably differentiate between NotFound and actual errors
+    Error {msg: String},
+}
+
+// This just wraps a message pack encoded string inside a resp bulk string
+impl Format for Req {
+    fn format(&self) -> Combinator {
+        let c = Combinator::new();
+        let data = Encoder::to_msgpack(&self).unwrap();
+        c.bulk(data)
+    }
+}
+
+impl Parse for Req {
+    fn parsers() -> Vec<Parser<Req>> {
+        vec![Parser::<Req>::new(Box::new(|bulk| {
+            if let RespType::Bulk(data) = (*bulk).pop().unwrap() {
+                match from_msgpack(&data) {
+                    Err(e) => Err(Error::new(ErrorKind::InvalidInput, e)),
+                    Ok(val) => Ok(val)
+                }
+            } else {
+                assert!(false);
+                Err(Error::new(ErrorKind::InvalidInput, "Failed to parse VR Req"))
+            }
+        })).bulk(None)]
+    }
+}
+
+// This just wraps a message pack encoded string inside a resp bulk string
+impl Format for Rsp {
+    fn format(&self) -> Combinator {
+        let c = Combinator::new();
+        let data = Encoder::to_msgpack(&self).unwrap();
+        c.bulk(data)
+    }
+}
+
+impl Parse for Rsp {
+    fn parsers() -> Vec<Parser<Rsp>> {
+        vec![Parser::<Rsp>::new(Box::new(|bulk| {
+            if let RespType::Bulk(data) = (*bulk).pop().unwrap() {
+                match from_msgpack(&data) {
+                    Err(e) => Err(Error::new(ErrorKind::InvalidInput, e)),
+                    Ok(val) => Ok(val)
+                }
+            } else {
+                assert!(false);
+                Err(Error::new(ErrorKind::InvalidInput, "Failed to parse VR Rsp"))
+            }
+        })).bulk(None)]
+    }
+}
+

--- a/src/vr_api/mock_vr.rs
+++ b/src/vr_api/mock_vr.rs
@@ -1,0 +1,51 @@
+use std::sync::mpsc::{Sender, Receiver};
+use mio::Token;
+use super::messages::{Req, Rsp};
+use element::Version; // TODO: should this be in it's own file?
+use super::backend::VrBackend;
+
+pub enum VrReq {
+    Write(Token, Req),
+    Read(Token, Req)
+}
+
+pub struct VrResp(pub Token, pub Rsp);
+
+pub struct MockVr {
+    version: Version,
+    backend: VrBackend,
+    tx: Sender<VrResp>,
+    rx: Receiver<VrReq>
+}
+
+impl MockVr {
+    pub fn new(tx: Sender<VrResp>, rx: Receiver<VrReq>) -> MockVr {
+        MockVr {
+            backend: VrBackend::new(),
+            version: Version::new(),
+            tx: tx,
+            rx: rx
+        }
+    }
+
+    pub fn recv_loop(&mut self) {
+        loop {
+            match self.rx.recv().unwrap() {
+                VrReq::Write(token, msg) => self.handle_write(token, msg),
+                VrReq::Read(token, msg) => self.handle_read(token, msg)
+            }
+        }
+    }
+
+    fn handle_write(&mut self, token: Token, msg: Req) {
+        let version = self.version.inc();
+        let resp = self.backend.call(version, msg);
+        self.tx.send(VrResp(token, resp)).unwrap();
+    }
+
+    fn handle_read(&mut self, token: Token, msg: Req) {
+        let version = self.version.clone();
+        let resp = self.backend.call(version, msg);
+        self.tx.send(VrResp(token, resp)).unwrap();
+    }
+}

--- a/src/vr_api/mod.rs
+++ b/src/vr_api/mod.rs
@@ -1,0 +1,8 @@
+pub mod server;
+pub mod handler;
+mod messages;
+mod mock_vr;
+mod backend;
+
+pub use self::messages::{Req, Rsp};
+pub use self::handler::VrApiHandler;

--- a/src/vr_api/server.rs
+++ b/src/vr_api/server.rs
@@ -1,0 +1,29 @@
+use std::thread;
+use std::thread::JoinHandle;
+use std::sync::mpsc::channel;
+use event_loop::EventLoop;
+use state::State;
+use super::VrApiHandler;
+use super::mock_vr::MockVr;
+use tcphandler::TcpHandler;
+
+pub fn run(state: State)
+    -> Vec<JoinHandle<()>> {
+
+    let (req_tx, req_rx) = channel();
+    let (rpy_tx, rpy_rx) = channel();
+
+    let mut handler = VrApiHandler::new(state.clone(), req_tx, rpy_rx);
+    let mut mock_vr = MockVr::new(rpy_tx, req_rx);
+    let mut event_loop = EventLoop::<VrApiHandler>::new(state.clone(), handler.event_loop_sender());
+    handler.set_event_loop_tx(event_loop.sender());
+    let handle1 = event_loop.run();
+    let handle2 = thread::Builder::new().name("vr_api_server".to_string()).spawn(move || {
+        handler.recv_loop()
+    }).unwrap();
+    let handle3 = thread::Builder::new().name("mock_vr".to_string()).spawn(move || {
+        mock_vr.recv_loop()
+    }).unwrap();
+
+    vec![handle1, handle2, handle3]
+}


### PR DESCRIPTION
The API is currently message pack wrapped in Resp bulk strings for
framing. It's expected that it will be transitioned to another framing
mechanism such as a 4 byte header.

The API implements only a few commands, and so far only binary
representations actually work. The implemented commands are:
- Create - Create an element of a given type at some path
- Get
- Put (w/ CAS as an option)
- Delete (w/ CAS as an option)
- List - List keys under a given path

The API uses a mock VR layer that exists in it's own thread and receives
messages on a channel from the API handler. The mock VR layer doesn't
actually do anything but make upcalls to the backend data structure that
implements the API. Currently the backend uses a BTree to maintain
state, although it's expected that this will be replaced with some other
data structure that is easily snapshottable and able to be efficiently
persisted to disk. Each node maintains it's own separate btree, and
since the VR layer is just a stub, they are currently all independent
meaning that sending different operations to different nodes will result
in different responses.
