### PR TITLE
Clean up warnings from src.

### DIFF
--- a/src/admin/handler.rs
+++ b/src/admin/handler.rs
@@ -13,7 +13,6 @@ use std::sync::mpsc::{channel, Sender, Receiver};
 /// Handle all events from the event loop
 /// Maintain the internal state of the admin server
 pub struct AdminHandler {
-    node: String,
     state: State,
     cluster_tx: Sender<AdminMsg>,
     cluster_rx: Option<Receiver<AdminMsg>>,
@@ -58,7 +57,6 @@ impl AdminHandler {
 
         let (tx, rx) = channel();
         AdminHandler {
-            node: state.members.local_name(),
             state: state,
             cluster_tx: cluster_tx,
             cluster_rx: Some(cluster_rx),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![plugin(serde_macros)]
 #![feature(mpsc_select)]
 #![feature(btree_range, collections_bound)]
-#![feature(drain)]
 
 #[cfg(test)]
 extern crate quickcheck;

--- a/src/membership.rs
+++ b/src/membership.rs
@@ -96,6 +96,7 @@ impl Members {
     }
 
     // TODO: Only allow adding member if it doesn't exist
+    #[allow(dead_code)]
     pub fn add(&mut self, element: Member) -> Result<()> {
         let mut orset = self.orset.write().unwrap();
         (*orset).add(element);

--- a/src/orset.rs
+++ b/src/orset.rs
@@ -41,7 +41,8 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
             removes: HashMap::new()
         }
     }
-
+    
+    #[allow(dead_code)]
     fn seen(&self, element: &T) -> Option<Vec<Dot>> {
         match self.adds.get(element) {
             None => None,
@@ -65,6 +66,7 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
     }
 
     /// Invariant: seen can never be empty
+    #[allow(dead_code)]
     pub fn remove(&mut self, element: T, seen: Vec<Dot>) -> Delta<T> {
         assert!(seen.len() != 0);
         let mut removes = self.removes.entry(element.clone()).or_insert(Vec::new());
@@ -99,6 +101,7 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
     }
 
     /// Returns true if the state was mutated, false otherwise
+    #[allow(dead_code)]
     pub fn join(&mut self, delta: Delta<T>) -> bool {
         match delta {
             Delta::Add {element, dot} => self.join_add(element, dot),
@@ -141,6 +144,7 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
         return mutated
     }
 
+    #[allow(dead_code)]
     pub fn contains(&self, element: &T) -> bool {
         if let Some(adds) = self.adds.get(element) {
             if adds.is_empty() {

--- a/src/vr/dispatcher.rs
+++ b/src/vr/dispatcher.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::iter::FromIterator;
 use uuid::Uuid;
-use fsm::{Fsm, Msg, StateFn};
+use fsm::{Fsm, Msg};
 use membership::Member;
 use super::replica::{RawReplica, Replica, VersionedReplicas};
 use super::vr_fsm::{StartupState, VrCtx, VrHandler, DEFAULT_IDLE_TIMEOUT_MS, DEFAULT_PRIMARY_TICK_MS};
@@ -176,7 +176,7 @@ impl Dispatcher {
         }
     }
 
-    pub fn send_remote(&mut self, to: &Replica, msg: Msg) {
+    pub fn send_remote(&mut self, _to: &Replica, _msg: Msg) {
         unimplemented!();
     }
 
@@ -187,7 +187,9 @@ impl Dispatcher {
                     self.tenants.get_mut(&tenant) {
 
                     // This is an old reconfig message
-                    if (new_config.epoch <= saved_new_config.epoch) { return; }
+                    if new_config.epoch <= saved_new_config.epoch { 
+                        return; 
+                    }
                     let new_set = HashSet::<Replica>::from_iter(new_config.replicas.clone());
                     // We want to use the actual running nodes here because we are trying to determine which
                     // nodes to start locally
@@ -280,7 +282,7 @@ impl Dispatcher {
     //  new primary replays any uncommitted client operations. This allows us to just drop them and
     // get a response to the latest client request.
     pub fn drop_all_client_replies(&self) {
-        while let Ok(envelope) = self.client_reply_receiver.try_recv() {};
+        while let Ok(_envelope) = self.client_reply_receiver.try_recv() {};
     }
 
     #[cfg(debug_assertions)]

--- a/src/vr/vr_fsm.rs
+++ b/src/vr/vr_fsm.rs
@@ -402,7 +402,7 @@ pub fn transitioning_to_replace(ctx: &mut VrCtx, msg: VrMsg) -> StateFn<VrHandle
 
 /// This replica has already told the dispatcher to shut it down. It just waits in this state and
 /// doesn't respond to any messages from this point out.
-pub fn shutdown(ctx: &mut VrCtx, _: VrMsg) -> StateFn<VrHandler> {
+pub fn shutdown(_ctx: &mut VrCtx, _: VrMsg) -> StateFn<VrHandler> {
     next!(shutdown)
 }
 
@@ -468,7 +468,7 @@ pub fn state_transfer(ctx: &mut VrCtx, msg: VrMsg) -> StateFn<VrHandler> {
     check_epoch!(ctx, msg, state_transfer);
     check_view!(ctx, msg, state_transfer);
     match msg {
-        VrMsg::NewState {view, ..} => {
+        VrMsg::NewState {..} => {
             set_state(ctx, msg);
             next!(backup)
         },
@@ -487,7 +487,7 @@ fn reset_and_start_view_change(ctx: &mut VrCtx) -> StateFn<VrHandler> {
     start_view_change(ctx)
 }
 
-fn learn_config(ctx: &mut VrCtx, epoch: u64) -> StateFn<VrHandler> {
+fn learn_config(_ctx: &mut VrCtx, _epoch: u64) -> StateFn<VrHandler> {
     unimplemented!();
 }
 
@@ -495,7 +495,7 @@ fn learn_config(ctx: &mut VrCtx, epoch: u64) -> StateFn<VrHandler> {
 // only be a reconfig or client request in the log.
 fn rebroadcast_reconfig(ctx: &mut VrCtx) {
     let reconfig = ctx.log[(ctx.op - 1) as usize].clone();
-    if let VrMsg::Reconfiguration {client_id, client_req_num, replicas, ..} = reconfig {
+    if let VrMsg::Reconfiguration {client_id, client_req_num, ..} = reconfig {
         let prepare = VrMsg::Prepare {
             epoch: ctx.epoch,
             view: ctx.view,
@@ -906,7 +906,7 @@ fn primary_commit_known_committed_ops(ctx: &mut VrCtx, last_commit_num: u64) {
             ctx.client_table.insert(client_id.clone(), (request_num, Some(reply.clone())));
             send_client_reply(ctx, client_id, reply);
         }
-        if let VrMsg::Reconfiguration {client_id, client_req_num, epoch, replicas} = msg {
+        if let VrMsg::Reconfiguration {client_id, client_req_num, epoch, ..} = msg {
             let rsp = ctx.backend.call(i+1, VrApiReq::Null);
             let reply = VrMsg::ClientReply {
                 epoch: epoch,

--- a/src/vr_api/backend.rs
+++ b/src/vr_api/backend.rs
@@ -71,7 +71,7 @@ impl VrBackend {
         Ok(VrApiRsp::KeyList {keys: keys})
     }
 
-    fn delete(&mut self, op: u64, path: String, cas_tag: Option<u64>)
+    fn delete(&mut self, _op: u64, path: String, cas_tag: Option<u64>)
         -> Result<VrApiRsp, VrApiRsp> {
 
         if let Some(element) = self.tree.remove(&path) {

--- a/src/vr_api/element.rs
+++ b/src/vr_api/element.rs
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-use std::string::ToString;
 
 #[derive(Debug, Clone, Eq, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum ElementType {

--- a/src/vr_api/handler.rs
+++ b/src/vr_api/handler.rs
@@ -4,16 +4,13 @@ use mio;
 use mio::Token;
 use state::State;
 use tcphandler::TcpHandler;
-use super::messages::{VrApiReq, VrApiRsp};
+use super::messages::{VrApiReq};
 use event::Event;
-use std::error;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use rustc_serialize::Encodable;
 use super::mock_vr::{VrReq, VrResp};
 
 pub struct VrApiHandler {
-    node: String,
-    state: State,
     vr_tx: Sender<VrReq>,
     vr_rx: Option<Receiver<VrResp>>,
     event_loop_tx: Option<mio::Sender<Notification>>,
@@ -52,11 +49,9 @@ impl TcpHandler for VrApiHandler {
 }
 
 impl VrApiHandler {
-    pub fn new(state: State, vr_tx: Sender<VrReq>, vr_rx: Receiver<VrResp> ) -> VrApiHandler {
+    pub fn new(_state: State, vr_tx: Sender<VrReq>, vr_rx: Receiver<VrResp> ) -> VrApiHandler {
         let (tx, rx) = channel();
         VrApiHandler {
-            node: state.members.local_name(),
-            state: state,
             vr_tx: vr_tx,
             vr_rx: Some(vr_rx),
             event_loop_tx: None,


### PR DESCRIPTION
Cleaning up warnings from src. We still need a round of clean up of the code.  
Tests continue to generate warnings but that needs a deeper investigations.
