### PR TITLE
Make orset a pub module.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@ pub mod state;
 pub mod resp;
 pub mod vr_api;
 pub mod vr;
+pub mod orset;
 
 mod event;
-mod orset;
 mod tcphandler;
 mod membership;
 

--- a/src/orset.rs
+++ b/src/orset.rs
@@ -42,8 +42,7 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
         }
     }
     
-    #[allow(dead_code)]
-    fn seen(&self, element: &T) -> Option<Vec<Dot>> {
+    pub fn seen(&self, element: &T) -> Option<Vec<Dot>> {
         match self.adds.get(element) {
             None => None,
             Some(dots) => {
@@ -66,7 +65,6 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
     }
 
     /// Invariant: seen can never be empty
-    #[allow(dead_code)]
     pub fn remove(&mut self, element: T, seen: Vec<Dot>) -> Delta<T> {
         assert!(seen.len() != 0);
         let mut removes = self.removes.entry(element.clone()).or_insert(Vec::new());
@@ -101,7 +99,6 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
     }
 
     /// Returns true if the state was mutated, false otherwise
-    #[allow(dead_code)]
     pub fn join(&mut self, delta: Delta<T>) -> bool {
         match delta {
             Delta::Add {element, dot} => self.join_add(element, dot),
@@ -144,7 +141,6 @@ impl<T: Eq + Hash + Clone> ORSet<T> {
         return mutated
     }
 
-    #[allow(dead_code)]
     pub fn contains(&self, element: &T) -> bool {
         if let Some(adds) = self.adds.get(element) {
             if adds.is_empty() {


### PR DESCRIPTION
The API for the orset should be public including the module. It also eliminates the need for marking certain code as dead.
