### PR TITLE
Correct v2r2-cli-client example and improve incorrect usage behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Run the tests with `cargo test`
  * Noting the tenant id and primary from the last step, open a third terminal window
  * Run the CLI client, giving the primary replica to talk to (in this case r2), and the VR API port
    to listen on (in this case 3002).
-   * `rlwrap cargo run --bin v2r2-cli-client <UUID>::r2::dev2 127.0.0.1:3002`
+   * `rlwrap cargo run --bin v2r2-cli-client <UUID> 127.0.0.1:3002`
  * Start issuing commands
 
 ```
@@ -64,7 +64,7 @@ v2r2> create binary /foo
    output logging.
  * Connect to the new master (in this case dev3) with the cli client and run some operations, ensuring the state is
    correct
-   * `rlwrap cargo run --bin v2r2-cli-client <UUID>::r3::dev3 127.0.0.1:4002`
+   * `rlwrap cargo run --bin v2r2-cli-client <UUID> 127.0.0.1:4002`
 
 ```
 v2r2> get /foo cas

--- a/src/bin/v2r2-cli-client.rs
+++ b/src/bin/v2r2-cli-client.rs
@@ -20,8 +20,31 @@ static mut req_num: u64 = 0;
 
 fn main() {
     let mut args = env::args();
-    let tenant_id = Uuid::parse_str(&args.nth(1).unwrap()).unwrap();
-    let addr = args.next().unwrap();
+
+    let tenant_id: Uuid = match args.nth(1) {
+        Some(arg1) => {
+            match Uuid::parse_str(&arg1) {
+                Ok(uuid) => uuid,
+                Err(_) => {
+                    println!("Invalid UUID format\n{}", help());
+                    exit(-1);
+                }
+            }
+        },
+        None => {
+            println!("Missing argument UUID\n{}", help());
+            exit(-1);
+        }
+    };
+
+    let addr: String = match args.next() {
+        Some(ipport) => ipport,
+        None => {
+            println!("Missing IP Address\n{}", help());
+            exit(-1);
+        }
+    };
+
     let (primary, sock, session_id) = start_session(tenant_id, addr);
     if let Some(flag) = args.next() {
         run_script(&flag, args, sock, &primary, session_id);
@@ -296,7 +319,7 @@ fn exec(msg: VrApiReq, sock: &mut TcpStream, replica: &Replica, session_id: Uuid
 
 fn help() -> Error {
     let string  =
-"Usage: v2r2-cli-client <IpAddress> [-e <command>]
+"Usage: v2r2-cli-client <UUID> <IpAddress> [-e <command>]
 
     Commands:
         create <Element Type> <Path>


### PR DESCRIPTION
v2r2-cli-client expects a UUID, not <UUID>::<replica>::<node>,
as the readme had said. Correct the readme and help message.

Also check the args and print a more helpful message if they're
wrong or missing.

_This is my first Rust code, so please let me know if there's a more idiomatic way to do this._
