### PR TITLE
specify the shell for gmake so 'for' works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ run:
 test:
 	cargo test
 
+SHELL := /bin/bash
 .PHONY: devrel launch stop start-dev% stop-dev%
 NUM_NODES=3
 nodes := $(shell eval "for ((i=1; i<=${NUM_NODES}; i++)); do echo dev\$${i}; done")


### PR DESCRIPTION
otherwise gmake will default to /bin/sh, which throws a sad at the bash for loop syntax.