### PR TITLE
Add `lint` target for Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ run:
 test:
 	cargo test
 
+lint:
+	@echo cargo clipppy
+	@cargo clippy || (echo "Install clippy with 'cargo install clippy'"; exit 1)
+
 SHELL := /bin/bash
 .PHONY: devrel launch stop start-dev% stop-dev%
 NUM_NODES=3


### PR DESCRIPTION
Add `lint` target to Makefile. This currently expects to have clippy
installed. If it is not, it errors out as you would expect, but also
echos a message with instructions on how to install clippy.

Closes #23