### PR TITLE
Use rustfmt to format code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,8 @@
+fn_call_width = 80
+struct_trailing_comma = "Never"
+struct_lit_trailing_comma = "Never"
+enum_trailing_comma = false
+match_wildcard_trailing_comma = false
+type_punctuation_density = "Compressed"
+wrap_match_arms = false
+use_try_shorthand = true

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ lint:
 	@echo cargo clipppy
 	@cargo clippy || (echo "Install clippy with 'cargo install clippy'"; exit 1)
 
+format:
+	@which rustfmt || cargo install rustfmt
+	cargo fmt -- --write-mode=overwrite
+
 SHELL := /bin/bash
 .PHONY: devrel launch stop start-dev% stop-dev%
 NUM_NODES=3


### PR DESCRIPTION
This adds a Makefile target to run rustfmt. It only writes a diff to
screen. It could be changed to replace and create backups or overwrite
without backups. I chose this to prevent overwriting things that may
not be desirable to change.

This also adds a .rustfmt.toml to account for long lines (the default is
100 and errors out on a few lines in the project).

Closes #22