### PR TITLE
Format code with rustfmt

### DIFF
--- a/src/admin/messages.rs
+++ b/src/admin/messages.rs
@@ -39,4 +39,3 @@ pub enum AdminRpy {
     ClusterStatus(ClusterStatus),
     Metrics(Vec<(String, Metric)>)
 }
-

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -6,8 +6,4 @@ mod messages;
 
 pub use self::connection_handler::AdminConnectionHandler;
 
-pub use self::messages::{
-    AdminMsg,
-    AdminReq,
-    AdminRpy
-};
+pub use self::messages::{AdminMsg, AdminReq, AdminRpy};

--- a/src/api/connection_handler.rs
+++ b/src/api/connection_handler.rs
@@ -15,8 +15,11 @@ type Milliseconds = u64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ApiRpy {
-    ClientRegistration {primary: Pid, new_registration: bool},
-    Redirect {primary: Pid, api_addr: String},
+    ClientRegistration {
+        primary: Pid,
+        new_registration: bool
+    },
+    Redirect { primary: Pid, api_addr: String },
     Retry(Milliseconds),
     UnknownNamespace
 }
@@ -52,8 +55,7 @@ impl ApiConnectionHandler {
 
     fn handle_register_client(&mut self,
                               mut msg: RegisterClient,
-                              output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
+                              output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
         let client_id = msg.take_client_id();
         let namespace_id = msg.take_namespace_id();
         let pid = self.namespace_mgr.clone();
@@ -65,8 +67,7 @@ impl ApiConnectionHandler {
 
     fn handle_consensus_request(&mut self,
                                 mut msg: ConsensusRequest,
-                                output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
+                                output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
         let mut api_pid = msg.take_to();
         let pid = Pid {
             name: api_pid.take_name(),
@@ -79,11 +80,7 @@ impl ApiConnectionHandler {
         let client_id = msg.take_client_id();
         let client_req_num = msg.get_client_request_num();
         if msg.has_tree_op() {
-            return self.handle_tree_op(pid,
-                                       client_id,
-                                       client_req_num,
-                                       msg.take_tree_op(),
-                                       output);
+            return self.handle_tree_op(pid, client_id, client_req_num, msg.take_tree_op(), output);
         }
         if msg.has_tree_cas() {
             return self.handle_tree_cas(pid,
@@ -150,8 +147,7 @@ impl ApiConnectionHandler {
                       client_id: String,
                       client_req_num: u64,
                       msg: TreeOp,
-                      output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
+                      output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
         let vr_api_req = VrApiReq::TreeOp(self.proto_tree_op_to_vr_tree_op(msg));
         self.send_client_request(pid, client_id, client_req_num, vr_api_req, output)
     }
@@ -161,14 +157,24 @@ impl ApiConnectionHandler {
                        client_id: String,
                        client_req_num: u64,
                        mut msg: TreeCas,
-                       output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
-        let guards: Vec<_> = msg.take_guards().iter_mut().map(|g| {
-            vr::Guard {path: g.take_path(), version: g.get_version()}
-        }).collect();
-        let ops: Vec<_> = msg.take_tree_ops().into_iter()
-            .map(|op| self.proto_tree_op_to_vr_tree_op(op)).collect();
-        let vr_api_req = VrApiReq::TreeCas(vr::TreeCas { guards: guards, ops: ops });
+                       output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
+        let guards: Vec<_> = msg.take_guards()
+                                .iter_mut()
+                                .map(|g| {
+            vr::Guard {
+                path: g.take_path(),
+                version: g.get_version()
+            }
+        })
+                                .collect();
+        let ops: Vec<_> = msg.take_tree_ops()
+                             .into_iter()
+                             .map(|op| self.proto_tree_op_to_vr_tree_op(op))
+                             .collect();
+        let vr_api_req = VrApiReq::TreeCas(vr::TreeCas {
+                                               guards: guards,
+                                               ops: ops
+                                           });
         self.send_client_request(pid, client_id, client_req_num, vr_api_req, output)
     }
 
@@ -177,11 +183,12 @@ impl ApiConnectionHandler {
                            client_id: String,
                            client_req_num: u64,
                            req: VrApiReq,
-                           output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
-        let vrmsg = VrMsg::ClientRequest {op: req,
-                                          client_id: client_id,
-                                          request_num: client_req_num};
+                           output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
+        let vrmsg = VrMsg::ClientRequest {
+            op: req,
+            client_id: client_id,
+            request_num: client_req_num
+        };
         let envelope = self.make_envelope(pid, Msg::Vr(vrmsg));
         output.push(ConnectionMsg::Envelope(envelope));
     }
@@ -192,129 +199,173 @@ impl ApiConnectionHandler {
             NodeType::BLOB => vr::NodeType::Blob,
             NodeType::QUEUE => vr::NodeType::Queue,
             NodeType::SET => vr::NodeType::Set,
-            NodeType::DIRECTORY => vr::NodeType::Directory
+            NodeType::DIRECTORY => vr::NodeType::Directory,
         };
-        vr::TreeOp::CreateNode{path: path, ty: node_type}
+        vr::TreeOp::CreateNode {
+            path: path,
+            ty: node_type
+        }
     }
 
     fn to_vr_delete_node(&mut self, mut msg: DeleteNode) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::DeleteNode {path: path}
+        vr::TreeOp::DeleteNode { path: path }
     }
 
     fn to_vr_list_keys(&mut self, mut msg: ListKeys) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::ListKeys {path: path}
+        vr::TreeOp::ListKeys { path: path }
     }
 
     fn to_vr_blob_put(&mut self, mut msg: BlobPut) -> vr::TreeOp {
         let path = msg.take_path();
         let val = msg.take_val();
-        vr::TreeOp::BlobPut {path: path, val: val}
+        vr::TreeOp::BlobPut {
+            path: path,
+            val: val
+        }
     }
 
     fn to_vr_blob_get(&mut self, mut msg: BlobGet) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::BlobGet {path: path}
+        vr::TreeOp::BlobGet { path: path }
     }
 
     fn to_vr_blob_size(&mut self, mut msg: BlobSize) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::BlobSize {path: path}
+        vr::TreeOp::BlobSize { path: path }
     }
 
     fn to_vr_queue_push(&mut self, mut msg: QueuePush) -> vr::TreeOp {
         let path = msg.take_path();
         let val = msg.take_val();
-        vr::TreeOp::QueuePush {path: path, val: val}
+        vr::TreeOp::QueuePush {
+            path: path,
+            val: val
+        }
     }
 
     fn to_vr_queue_pop(&mut self, mut msg: QueuePop) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::QueuePop {path: path}
+        vr::TreeOp::QueuePop { path: path }
     }
 
     fn to_vr_queue_front(&mut self, mut msg: QueueFront) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::QueueFront {path: path}
+        vr::TreeOp::QueueFront { path: path }
     }
 
     fn to_vr_queue_back(&mut self, mut msg: QueueBack) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::QueueBack {path: path}
+        vr::TreeOp::QueueBack { path: path }
     }
 
     fn to_vr_queue_len(&mut self, mut msg: QueueLen) -> vr::TreeOp {
         let path = msg.take_path();
-        vr::TreeOp::QueueLen{path: path}
+        vr::TreeOp::QueueLen { path: path }
     }
 
     fn to_vr_set_insert(&mut self, mut msg: SetInsert) -> vr::TreeOp {
         let path = msg.take_path();
         let val = msg.take_val();
-        vr::TreeOp::SetInsert {path: path, val: val}
+        vr::TreeOp::SetInsert {
+            path: path,
+            val: val
+        }
     }
 
     fn to_vr_set_remove(&mut self, mut msg: SetRemove) -> vr::TreeOp {
         let path = msg.take_path();
         let val = msg.take_val();
-        vr::TreeOp::SetRemove {path: path, val: val}
+        vr::TreeOp::SetRemove {
+            path: path,
+            val: val
+        }
     }
 
     fn to_vr_set_contains(&mut self, mut msg: SetContains) -> vr::TreeOp {
         let path = msg.take_path();
         let val = msg.take_val();
-        vr::TreeOp::SetContains {path: path, val: val}
+        vr::TreeOp::SetContains {
+            path: path,
+            val: val
+        }
     }
 
     fn to_vr_set_union(&mut self, mut msg: SetUnion) -> vr::TreeOp {
         let paths = msg.take_paths().into_vec();
-        let sets: Vec<_> = msg.take_sets().into_iter().map(|mut s| {
-            HashSet::from_iter(s.take_val().into_iter())
-        }).collect();
-        vr::TreeOp::SetUnion {paths: paths, sets: sets}
+        let sets: Vec<_> =
+            msg.take_sets()
+               .into_iter()
+               .map(|mut s| HashSet::from_iter(s.take_val().into_iter()))
+               .collect();
+        vr::TreeOp::SetUnion {
+            paths: paths,
+            sets: sets
+        }
     }
 
     fn to_vr_set_intersection(&mut self, mut msg: SetIntersection) -> vr::TreeOp {
         let path1 = msg.take_path1();
         let path2 = msg.take_path2();
-        vr::TreeOp::SetIntersection {path1: path1, path2: path2}
+        vr::TreeOp::SetIntersection {
+            path1: path1,
+            path2: path2
+        }
     }
 
     fn to_vr_set_difference(&mut self, mut msg: SetDifference) -> vr::TreeOp {
         let path1 = msg.take_path1();
         let path2 = msg.take_path2();
-        vr::TreeOp::SetDifference {path1: path1, path2: path2}
+        vr::TreeOp::SetDifference {
+            path1: path1,
+            path2: path2
+        }
     }
 
     fn to_vr_set_symmetric_difference(&mut self, mut msg: SetSymmetricDifference) -> vr::TreeOp {
         let path1 = msg.take_path1();
         let path2 = msg.take_path2();
-        vr::TreeOp::SetSymmetricDifference {path1: path1, path2: path2}
+        vr::TreeOp::SetSymmetricDifference {
+            path1: path1,
+            path2: path2
+        }
     }
 
     fn to_vr_set_subset_path(&mut self, mut msg: SetSubsetPath) -> vr::TreeOp {
         let path1 = msg.take_path1();
         let path2 = msg.take_path2();
-        vr::TreeOp::SetSubsetPath {path1: path1, path2: path2}
+        vr::TreeOp::SetSubsetPath {
+            path1: path1,
+            path2: path2
+        }
     }
 
     fn to_vr_set_subset_set(&mut self, mut msg: SetSubsetSet) -> vr::TreeOp {
         let path = msg.take_path();
         let set = HashSet::from_iter(msg.take_set().take_val().into_iter());
-        vr::TreeOp::SetSubsetSet {path: path, set: set}
+        vr::TreeOp::SetSubsetSet {
+            path: path,
+            set: set
+        }
     }
 
     fn to_vr_set_superset_path(&mut self, mut msg: SetSupersetPath) -> vr::TreeOp {
         let path1 = msg.take_path1();
         let path2 = msg.take_path2();
-        vr::TreeOp::SetSupersetPath {path1: path1, path2: path2}
+        vr::TreeOp::SetSupersetPath {
+            path1: path1,
+            path2: path2
+        }
     }
 
     fn to_vr_set_superset_set(&mut self, mut msg: SetSupersetSet) -> vr::TreeOp {
         let path = msg.take_path();
         let set = HashSet::from_iter(msg.take_set().take_val().into_iter());
-        vr::TreeOp::SetSupersetSet {path: path, set: set}
+        vr::TreeOp::SetSupersetSet {
+            path: path,
+            set: set
+        }
     }
 
     fn error(&self, err: ApiError) -> ConnectionMsg<ApiConnectionHandler> {
@@ -347,9 +398,12 @@ impl ConnectionHandler for ApiConnectionHandler {
 
     fn handle_envelope(&mut self,
                        envelope: Envelope<Msg>,
-                       output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
-        let Envelope {msg, correlation_id, ..} = envelope;
+                       output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
+        let Envelope {
+            msg,
+            correlation_id,
+            ..
+        } = envelope;
         let correlation_id = correlation_id.unwrap();
 
         // Ensure responses are recent
@@ -358,7 +412,12 @@ impl ConnectionHandler for ApiConnectionHandler {
         }
         self.waiting_for += 1;
         match msg {
-            rabble::Msg::User(Msg::Vr(VrMsg::ClientReply {epoch, view, request_num, value})) => {
+            rabble::Msg::User(Msg::Vr(VrMsg::ClientReply {
+                                          epoch,
+                                          view,
+                                          request_num,
+                                          value
+                                      })) => {
                 let mut reply = ConsensusReply::new();
                 reply.set_epoch(epoch);
                 reply.set_view(view);
@@ -367,9 +426,14 @@ impl ConnectionHandler for ApiConnectionHandler {
                 let mut msg = ApiMsg::new();
                 msg.set_response(response);
                 output.push(ConnectionMsg::Client(msg, correlation_id));
-            },
+            }
             rabble::Msg::User(Msg::AdminRpy(AdminRpy::Namespaces(namespaces))) => {
-                let ids: Vec<_> = namespaces.map.keys().cloned().map(|k| k.0.to_string()).collect();
+                let ids: Vec<_> =
+                    namespaces.map
+                              .keys()
+                              .cloned()
+                              .map(|k| k.0.to_string())
+                              .collect();
                 let mut namespaces = Namespaces::new();
                 namespaces.set_ids(RepeatedField::from_vec(ids));
                 let mut response = ApiResponse::new();
@@ -377,20 +441,20 @@ impl ConnectionHandler for ApiConnectionHandler {
                 let mut msg = ApiMsg::new();
                 msg.set_response(response);
                 output.push(ConnectionMsg::Client(msg, correlation_id));
-            },
+            }
             rabble::Msg::User(Msg::ApiRpy(reply)) => {
                 let response = api_rpy_to_proto_api_response(reply);
                 let mut msg = ApiMsg::new();
                 msg.set_response(response);
                 output.push(ConnectionMsg::Client(msg, correlation_id));
-            },
+            }
             rabble::Msg::Timeout => {
                 let mut response = ApiResponse::new();
                 response.set_timeout(true);
                 let mut msg = ApiMsg::new();
                 msg.set_response(response);
                 output.push(ConnectionMsg::Client(msg, correlation_id));
-            },
+            }
             _ => {
                 let err = self.error(VrApiError::InvalidMsg.into());
                 output.push(err);
@@ -402,8 +466,7 @@ impl ConnectionHandler for ApiConnectionHandler {
 
     fn handle_network_msg(&mut self,
                           mut msg: ApiMsg,
-                          output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>)
-    {
+                          output: &mut Vec<ConnectionMsg<ApiConnectionHandler>>) {
         if !msg.has_request() {
             let err = self.error(VrApiError::InvalidMsg.into());
             output.push(err);
@@ -427,7 +490,10 @@ impl ConnectionHandler for ApiConnectionHandler {
 
 fn api_rpy_to_proto_api_response(reply: ApiRpy) -> ApiResponse {
     match reply {
-        ApiRpy::ClientRegistration {primary, new_registration} => {
+        ApiRpy::ClientRegistration {
+            primary,
+            new_registration
+        } => {
             let pid = pid_to_api_pid(primary);
             let mut cr = ClientRegistration::new();
             cr.set_primary(pid);
@@ -435,8 +501,8 @@ fn api_rpy_to_proto_api_response(reply: ApiRpy) -> ApiResponse {
             let mut response = ApiResponse::new();
             response.set_client_registration(cr);
             response
-        },
-        ApiRpy::Redirect {primary, api_addr} => {
+        }
+        ApiRpy::Redirect { primary, api_addr } => {
             let pid = pid_to_api_pid(primary);
             let mut redirect = Redirect::new();
             redirect.set_primary(pid);
@@ -444,14 +510,14 @@ fn api_rpy_to_proto_api_response(reply: ApiRpy) -> ApiResponse {
             let mut response = ApiResponse::new();
             response.set_redirect(redirect);
             response
-        },
+        }
         ApiRpy::Retry(milliseconds) => {
             let mut retry = Retry::new();
             retry.set_milliseconds(milliseconds);
             let mut response = ApiResponse::new();
             response.set_retry(retry);
             response
-        },
+        }
         ApiRpy::UnknownNamespace => {
             let mut response = ApiResponse::new();
             response.set_unknown_namespace(true);
@@ -468,50 +534,54 @@ impl From<VrApiError> for ApiError {
                 let mut e = NotFound::new();
                 e.set_path(path);
                 api_error.set_not_found(e);
-            },
+            }
             VrApiError::AlreadyExists(path) => {
                 let mut e = AlreadyExists::new();
                 e.set_path(path);
                 api_error.set_already_exists(e);
-            },
+            }
             VrApiError::DoesNotExist(path) => {
                 let mut e = DoesNotExist::new();
                 e.set_path(path);
                 api_error.set_does_not_exist(e);
-            },
+            }
             VrApiError::WrongType(path, ty) => {
                 let mut e = WrongType::new();
                 e.set_path(path);
                 e.set_node_type(ty.into());
                 api_error.set_wrong_type(e);
-            },
+            }
             VrApiError::PathMustEndInDirectory(path) => {
                 let mut e = PathMustEndInDirectory::new();
                 e.set_path(path);
                 api_error.set_path_must_end_in_directory(e);
-            },
+            }
             VrApiError::PathMustBeAbsolute(path) => {
                 let mut e = PathMustBeAbsolute::new();
                 e.set_path(path);
                 api_error.set_path_must_be_absolute(e);
-            },
-            VrApiError::CasFailed {path, expected, actual} => {
+            }
+            VrApiError::CasFailed {
+                path,
+                expected,
+                actual
+            } => {
                 let mut e = CasFailed::new();
                 e.set_path(path);
                 e.set_expected(expected);
                 e.set_actual(actual);
                 api_error.set_cas_failed(e);
-            },
+            }
             VrApiError::BadFormat(s) => {
                 let mut e = BadFormat::new();
                 e.set_msg(s);
                 api_error.set_bad_format(e);
-            },
+            }
             VrApiError::Io(s) => {
                 let mut e = Io::new();
                 e.set_msg(s);
                 api_error.set_io(e);
-            },
+            }
             VrApiError::EncodingError(s) => {
                 let mut e = EncodingError::new();
                 e.set_msg(s);
@@ -521,13 +591,13 @@ impl From<VrApiError> for ApiError {
                 let mut e = InvalidCas::new();
                 e.set_msg(s);
                 api_error.set_invalid_cas(e);
-            },
+            }
             VrApiError::Msg(s) => api_error.set_msg(s),
             VrApiError::CannotDeleteRoot => api_error.set_cannot_delete_root(true),
             VrApiError::InvalidMsg => api_error.set_invalid_msg(true),
             VrApiError::Timeout => api_error.set_timeout(true),
             VrApiError::NotEnoughReplicas => api_error.set_not_enough_replicas(true),
-            VrApiError::BadEpoch => api_error.set_bad_epoch(true)
+            VrApiError::BadEpoch => api_error.set_bad_epoch(true),
         }
         api_error
     }
@@ -539,7 +609,7 @@ impl From<vr::NodeType> for NodeType {
             vr::NodeType::Blob => NodeType::BLOB,
             vr::NodeType::Queue => NodeType::QUEUE,
             vr::NodeType::Set => NodeType::SET,
-            vr::NodeType::Directory => NodeType::DIRECTORY
+            vr::NodeType::Directory => NodeType::DIRECTORY,
         }
     }
 }
@@ -547,31 +617,31 @@ impl From<vr::NodeType> for NodeType {
 impl From<vr::TreeOpResult> for TreeOpResult {
     fn from(result: vr::TreeOpResult) -> TreeOpResult {
         let (mut result, version) = match result {
-            vr::TreeOpResult::Ok(version) =>  {
+            vr::TreeOpResult::Ok(version) => {
                 let mut result = TreeOpResult::new();
                 result.set_ok(true);
                 (result, version)
-            },
-            vr::TreeOpResult::Empty(version) =>  {
+            }
+            vr::TreeOpResult::Empty(version) => {
                 let mut result = TreeOpResult::new();
                 result.set_empty(true);
                 (result, version)
-            },
+            }
             vr::TreeOpResult::Bool(b, version) => {
                 let mut result = TreeOpResult::new();
                 result.set_bool(b);
                 (result, version)
-            },
+            }
             vr::TreeOpResult::Blob(blob, version) => {
                 let mut result = TreeOpResult::new();
                 result.set_blob(blob);
                 (result, version)
-            },
+            }
             vr::TreeOpResult::Int(i, version) => {
                 let mut result = TreeOpResult::new();
                 result.set_int(i);
                 (result, version)
-            },
+            }
             vr::TreeOpResult::Set(set, version) => {
                 let val = RepeatedField::from_vec(set);
                 let mut set = Set::new();
@@ -579,14 +649,16 @@ impl From<vr::TreeOpResult> for TreeOpResult {
                 let mut result = TreeOpResult::new();
                 result.set_set(set);
                 (result, version)
-            },
+            }
             vr::TreeOpResult::Keys(keys) => {
-                let key_vec: Vec<_>  = keys.into_iter().map(|(name, version)| {
+                let key_vec: Vec<_> = keys.into_iter()
+                                          .map(|(name, version)| {
                     let mut key = Key::new();
                     key.set_name(name);
                     key.set_version(version);
                     key
-                }).collect();
+                })
+                                          .collect();
                 let mut keys = Keys::new();
                 keys.set_keys(RepeatedField::from_vec(key_vec));
                 let mut result = TreeOpResult::new();
@@ -604,15 +676,15 @@ impl From<vr::TreeOpResult> for TreeOpResult {
 fn vr_api_rsp_to_proto_api_response(mut reply: ConsensusReply, value: VrApiRsp) -> ApiResponse {
     match value {
         VrApiRsp::Ok => reply.set_ok(true),
-        VrApiRsp::TreeOpResult(result) =>  reply.set_tree_op_result(result.into()),
+        VrApiRsp::TreeOpResult(result) => reply.set_tree_op_result(result.into()),
         VrApiRsp::TreeCasResult(results) => {
             let results: Vec<_> = results.into_iter().map(|op| op.into()).collect();
             let mut result = TreeCasResult::new();
             result.set_results(RepeatedField::from_vec(results));
             reply.set_tree_cas_result(result);
-        },
+        }
         VrApiRsp::Path(path) => reply.set_path(path),
-        VrApiRsp::Error(error) => reply.set_error(error.into())
+        VrApiRsp::Error(error) => reply.set_error(error.into()),
     }
     let mut response = ApiResponse::new();
     response.set_consensus_reply(reply);
@@ -629,4 +701,3 @@ fn pid_to_api_pid(pid: Pid) -> ApiPid {
     }
     api_pid
 }
-

--- a/src/bin/devconfig.rs
+++ b/src/bin/devconfig.rs
@@ -13,8 +13,8 @@ fn main() {
     n = 1000 + n * 1000;
 
     let cluster_port = n.to_string();
-    let admin_port = (n+1).to_string();
-    let api_port = (n+2).to_string();
+    let admin_port = (n + 1).to_string();
+    let api_port = (n + 2).to_string();
 
     let mut cluster_host = "127.0.0.1:".to_string();
     cluster_host.push_str(&cluster_port);
@@ -29,7 +29,7 @@ fn main() {
         node_name: name,
         cluster_host: cluster_host,
         admin_host: admin_host,
-        api_host: api_host,
+        api_host: api_host
     };
     config.write_path("config.json").unwrap();
 }

--- a/src/bin/haret-cli-client.rs
+++ b/src/bin/haret-cli-client.rs
@@ -57,7 +57,7 @@ fn run_interactive(mut client: HaretClient) {
         }
         match run(command, &mut client) {
             Ok(result) => println!("{}", result),
-            Err(err) => println!("{}", err)
+            Err(err) => println!("{}", err),
         }
     }
 }
@@ -82,7 +82,7 @@ fn run_script(flag: &str, mut args: Args, mut client: HaretClient) {
 }
 
 fn run(command: String, mut client: &mut HaretClient) -> Result<String> {
-    let req = try!(parse(command, &mut client));
+    let req = parse(command, &mut client)?;
     exec(req, client)
 }
 
@@ -96,114 +96,112 @@ struct Command {
     pattern: &'static str,
     description: &'static str,
     handler: fn(Vec<&str>, &mut HaretClient) -> ApiRequest,
-    consensus: bool,
+    consensus: bool
 }
 
 fn commands() -> Vec<Command> {
-    vec![
-        Command {
-            pattern: "list-namespaces",
-            description: "List all namespaces",
-            handler: list_namespaces,
-            consensus: false
-        },
-        Command {
-            pattern: "enter $namespace_id",
-            description: "Enter a namespace to issue consensus requests",
-            handler: enter_namespace,
-            consensus: false
-        },
-        Command {
-            pattern: "ls",
-            description: "List all keys in the current namespace",
-            handler: ls,
-            consensus: true,
-        },
-        Command {
-            pattern: "create *blob,set,queue $path",
-            description: "Create a new node at <path> of type blob, set or queue",
-            handler: create,
-            consensus: true,
-        },
-        Command {
-            pattern: "blob put $key $val",
-            description: "Put a blob to the given key",
-            handler: blob_put,
-            consensus: true,
-        },
-        Command {
-            pattern: "blob get $key",
-            description: "Get a blob from the given key",
-            handler: blob_get,
-            consensus: true,
-        },
-        Command {
-            pattern: "blob size $key",
-            description: "Get the size of the blob at the given key",
-            handler: blob_size,
-            consensus: true,
-        },
-        Command {
-            pattern : "queue push $path $val",
-            description: "Push a blob onto the back of the queue at <path>",
-            handler: queue_push,
-            consensus: true,
-        },
-        Command {
-            pattern: "queue pop $path",
-            description: "Pop a blob off the front of the queue at <path>",
-            handler: queue_pop,
-            consensus: true,
-        },
-        Command {
-            pattern: "queue front $path",
-            description: "Get a copy of the blob at the front of the queue without removing it",
-            handler: queue_front,
-            consensus: true,
-        },
-        Command {
-            pattern: "queue back $path",
-            description: "Get a copy of the blob at the back of the queue without removing it",
-            handler: queue_back,
-            consensus: true,
-        },
-        Command {
-            pattern: "queue len $path",
-            description: "Get the lenght of the queue at <path>",
-            handler: queue_len,
-            consensus: true,
-        },
-        Command {
-            pattern : "set insert $path $val",
-            description: "Insert a blob into the set at <path>",
-            handler: set_insert,
-            consensus: true,
-        },
-        Command {
-            pattern : "set remove $path $val",
-            description: "Remove a blob from the set at <path>",
-            handler: set_remove,
-            consensus: true,
-        },
-        Command {
-            pattern : "set contains $path $val",
-            description: "Return true if the set at <path> contains <val>",
-            handler: set_contains,
-            consensus: true,
-        },
-        Command {
-            pattern : "set union +path",
-            description: "Return the union of the sets at the given paths",
-            handler: set_union,
-            consensus: true,
-        },
-        Command {
-            pattern: "set intersection $path1 $path2",
-            description: "Return the intersection of the sets at the given paths",
-            handler: set_intersection,
-            consensus: true,
-        }
-    ]
+    vec![Command {
+             pattern: "list-namespaces",
+             description: "List all namespaces",
+             handler: list_namespaces,
+             consensus: false
+         },
+         Command {
+             pattern: "enter $namespace_id",
+             description: "Enter a namespace to issue consensus requests",
+             handler: enter_namespace,
+             consensus: false
+         },
+         Command {
+             pattern: "ls",
+             description: "List all keys in the current namespace",
+             handler: ls,
+             consensus: true
+         },
+         Command {
+             pattern: "create *blob,set,queue $path",
+             description: "Create a new node at <path> of type blob, set or queue",
+             handler: create,
+             consensus: true
+         },
+         Command {
+             pattern: "blob put $key $val",
+             description: "Put a blob to the given key",
+             handler: blob_put,
+             consensus: true
+         },
+         Command {
+             pattern: "blob get $key",
+             description: "Get a blob from the given key",
+             handler: blob_get,
+             consensus: true
+         },
+         Command {
+             pattern: "blob size $key",
+             description: "Get the size of the blob at the given key",
+             handler: blob_size,
+             consensus: true
+         },
+         Command {
+             pattern: "queue push $path $val",
+             description: "Push a blob onto the back of the queue at <path>",
+             handler: queue_push,
+             consensus: true
+         },
+         Command {
+             pattern: "queue pop $path",
+             description: "Pop a blob off the front of the queue at <path>",
+             handler: queue_pop,
+             consensus: true
+         },
+         Command {
+             pattern: "queue front $path",
+             description: "Get a copy of the blob at the front of the queue without removing it",
+             handler: queue_front,
+             consensus: true
+         },
+         Command {
+             pattern: "queue back $path",
+             description: "Get a copy of the blob at the back of the queue without removing it",
+             handler: queue_back,
+             consensus: true
+         },
+         Command {
+             pattern: "queue len $path",
+             description: "Get the lenght of the queue at <path>",
+             handler: queue_len,
+             consensus: true
+         },
+         Command {
+             pattern: "set insert $path $val",
+             description: "Insert a blob into the set at <path>",
+             handler: set_insert,
+             consensus: true
+         },
+         Command {
+             pattern: "set remove $path $val",
+             description: "Remove a blob from the set at <path>",
+             handler: set_remove,
+             consensus: true
+         },
+         Command {
+             pattern: "set contains $path $val",
+             description: "Return true if the set at <path> contains <val>",
+             handler: set_contains,
+             consensus: true
+         },
+         Command {
+             pattern: "set union +path",
+             description: "Return the union of the sets at the given paths",
+             handler: set_union,
+             consensus: true
+         },
+         Command {
+             pattern: "set intersection $path1 $path2",
+             description: "Return the intersection of the sets at the given paths",
+             handler: set_intersection,
+             consensus: true
+         }]
 }
 
 fn pattern_to_help_string(pattern: &str) -> String {
@@ -258,8 +256,12 @@ fn make_help() -> String {
     let commands = commands();
     let mut s = "Usage: haret-cli-client <IpAddress> [-e <command>]\n\n".to_string();
     s.push_str("    Commands\n");
-    let help_patterns: Vec<_> = commands.iter().map(|c| pattern_to_help_string(&c.pattern)).collect();
-    let column2_pos = help_patterns.iter().fold(0, |acc, p| {
+    let help_patterns: Vec<_> =
+        commands.iter()
+                .map(|c| pattern_to_help_string(&c.pattern))
+                .collect();
+    let column2_pos = help_patterns.iter()
+                                   .fold(0, |acc, p| {
         if p.len() > acc {
             return p.len();
         }
@@ -271,8 +273,7 @@ fn make_help() -> String {
         s.push_str(command.description);
         s.push('\n');
     }
-    let rest =
-"
+    let rest = "
     Flags:
         -e <Command>   Non-interactive mode
 
@@ -302,7 +303,10 @@ fn pattern_match(pattern: &'static str, argv: &Vec<&str>) -> bool {
             return true;
         }
         if pattern.starts_with("*") {
-            if pattern[1..].split(",").find(|option| arg == option).is_none() {
+            if pattern[1..]
+                   .split(",")
+                   .find(|option| arg == option)
+                   .is_none() {
                 println!("Argument must be one of: {}", pattern);
                 return false;
             }
@@ -310,7 +314,9 @@ fn pattern_match(pattern: &'static str, argv: &Vec<&str>) -> bool {
         }
         pattern == *arg
     });
-    if matched == false { return false; }
+    if matched == false {
+        return false;
+    }
     if !varargs && pattern.split_whitespace().count() != argv.len() {
         return false;
     }
@@ -326,7 +332,7 @@ fn parse(argv: String, mut client: &mut HaretClient) -> Result<ApiRequest> {
                     <namespace_id>`.";
                 return Err(Error::new(ErrorKind::InvalidInput, msg));
             }
-            return Ok((command.handler)(args, &mut client))
+            return Ok((command.handler)(args, &mut client));
         }
     }
     Err(Error::new(ErrorKind::InvalidInput, "Invalid Input. Type 'help' for commands"))
@@ -384,7 +390,7 @@ fn create(mut args: Vec<&str>, client: &mut HaretClient) -> ApiRequest {
         "blob" => NodeType::BLOB,
         "queue" => NodeType::QUEUE,
         "set" => NodeType::SET,
-        _ => unreachable!()
+        _ => unreachable!(),
     };
     let mut create_node = CreateNode::new();
     create_node.set_path(path.to_string());
@@ -554,12 +560,15 @@ fn tree_op_result_to_string(mut result: TreeOpResult) -> String {
 fn format_blob(blob: Vec<u8>) -> String {
     match String::from_utf8(blob) {
         Ok(s) => format!("{}\n", s),
-        Err(e) => format!("{:?}\n", e.into_bytes())
+        Err(e) => format!("{:?}\n", e.into_bytes()),
     }
 }
 
 fn format_set(mut set: Set) -> String {
-    set.take_val().into_vec().into_iter().fold(String::new(), |mut acc, blob| {
+    set.take_val()
+       .into_vec()
+       .into_iter()
+       .fold(String::new(), |mut acc, blob| {
         acc.push_str(&format_blob(blob));
         acc
     })
@@ -607,14 +616,16 @@ fn api_error_to_string(mut error: ApiError) -> String {
 }
 
 fn exec(req: ApiRequest, client: &mut HaretClient) -> Result<String> {
-    try!(client.write_msg(req).map_err(|_| {
+    client.write_msg(req)
+          .map_err(|_| {
         Error::new(ErrorKind::NotConnected,
                    "Failed to write to socket. Please restart client and try again".to_string())
-    }));
-    let mut api_response = try!(client.read_msg().map_err(|_| {
+    })?;
+    let mut api_response = client.read_msg()
+                                 .map_err(|_| {
         Error::new(ErrorKind::NotConnected,
                    "Failed to read from socket. Please restart client and try again".to_string())
-    }));
+    })?;
 
     if api_response.has_consensus_reply() {
         let mut consensus_reply = api_response.take_consensus_reply();
@@ -626,11 +637,13 @@ fn exec(req: ApiRequest, client: &mut HaretClient) -> Result<String> {
         }
 
         if consensus_reply.has_tree_op_result() {
-           s.push_str(&tree_op_result_to_string(consensus_reply.take_tree_op_result()));
+            s.push_str(&tree_op_result_to_string(consensus_reply.take_tree_op_result()));
         }
 
         if consensus_reply.has_tree_cas_result() {
-            for result in consensus_reply.take_tree_cas_result().take_results().into_iter() {
+            for result in consensus_reply.take_tree_cas_result()
+                                         .take_results()
+                                         .into_iter() {
                 s.push_str(&tree_op_result_to_string(result));
             }
         }
@@ -646,18 +659,19 @@ fn exec(req: ApiRequest, client: &mut HaretClient) -> Result<String> {
         }
 
         s.push_str(&format!("Epoch = {}, View = {}, Client Request Num = {}",
-                            consensus_reply.get_epoch(),
-                            consensus_reply.get_view(),
-                            consensus_reply.get_request_num()));
+                           consensus_reply.get_epoch(),
+                           consensus_reply.get_view(),
+                           consensus_reply.get_request_num()));
         return Ok(s);
     }
 
     if api_response.has_namespaces() {
         let namespaces = api_response.take_namespaces().take_ids().to_vec();
-        return Ok(namespaces.iter().fold(String::new(), |mut acc, namespace_id | {
-                acc.push_str(&namespace_id);
-                acc.push_str("\n");
-                acc
+        return Ok(namespaces.iter()
+                            .fold(String::new(), |mut acc, namespace_id| {
+            acc.push_str(&namespace_id);
+            acc.push_str("\n");
+            acc
         }));
     }
 
@@ -670,18 +684,18 @@ fn exec(req: ApiRequest, client: &mut HaretClient) -> Result<String> {
         let mut redirect = api_response.take_redirect();
         let primary = redirect.take_primary();
         let api_addr = redirect.take_api_addr();
-        try!(client.connect(Some(api_addr)));
-        let req = try!(client.register(Some(primary.clone())));
+        client.connect(Some(api_addr))?;
+        let req = client.register(Some(primary.clone()))?;
         /// Todo: Remove this recursion to prevent potential stack overflow
-        try!(exec(req, client));
+        exec(req, client)?;
         return Ok(format!("Finished Redirecting. Primary = {:?}, API Address = {}",
-                   client.primary.as_ref().unwrap(),
-                   client.api_addr.as_ref().unwrap()))
+                          client.primary.as_ref().unwrap(),
+                          client.api_addr.as_ref().unwrap()));
     }
 
     if api_response.has_retry() {
         let duration = api_response.take_retry().get_milliseconds();
-        return Ok(format!("Primary not found. Please retry in {} seconds.", duration*1000));
+        return Ok(format!("Primary not found. Please retry in {} seconds.", duration * 1000));
     }
 
     if api_response.has_unknown_namespace() {
@@ -701,8 +715,10 @@ fn help() -> Error {
 
 
 // TODO: Put HaretClient into it's own crate
-/// This struct represents the Haret client implementation in rust. It is a low level client that is
-/// useful for building higher level native clients or for building clients in other langauges via
+/// This struct represents the Haret client implementation in rust. It is a low
+/// level client that is
+/// useful for building higher level native clients or for building clients in
+/// other langauges via
 /// FFI.
 struct HaretClient {
     pub client_id: String,
@@ -734,18 +750,19 @@ impl HaretClient {
     pub fn connect(&mut self, api_addr: Option<String>) -> Result<()> {
         if api_addr.is_none() && self.api_addr.is_none() {
             return Err(Error::new(ErrorKind::InvalidInput,
-                              "API Address unknown. Please call connect with an api_addr."));
+                                  "API Address unknown. Please call connect with an api_addr."));
         }
         if api_addr.is_some() {
             self.api_addr = api_addr;
         }
-        self.sock = Some(try!(TcpStream::connect(&self.api_addr.as_ref().unwrap()[..])));
+        self.sock = Some(TcpStream::connect(&self.api_addr.as_ref().unwrap()[..])?);
         Ok(())
     }
 
     /// Register the client id on this node for the given namespace.
     ///
-    /// This function returns the registration message to be written or an error if the primary is
+    /// This function returns the registration message to be written or an
+    /// error if the primary is
     /// unknown.
     pub fn register(&mut self, primary: Option<ApiPid>) -> Result<ApiRequest> {
         if primary.is_none() && self.primary.is_none() {
@@ -754,8 +771,7 @@ impl HaretClient {
 
         if primary.is_some() {
             self.primary = primary;
-            self.namespace_id = Some(self.primary.as_ref().unwrap()
-                                     .get_group().to_string());
+            self.namespace_id = Some(self.primary.as_ref().unwrap().get_group().to_string());
         }
         let namespace_id = self.namespace_id.clone();
         let mut msg = RegisterClient::new();
@@ -769,27 +785,27 @@ impl HaretClient {
     fn write_msg(&mut self, req: ApiRequest) -> Result<()> {
         let mut msg = ApiMsg::new();
         msg.set_request(req);
-        let encoded = try!(msg.write_to_bytes().map_err(|_| {
+        let encoded = msg.write_to_bytes()
+                         .map_err(|_| {
             Error::new(ErrorKind::InvalidInput, "Failed to encode msgpack data")
-        }));
+        })?;
         let len: u32 = encoded.len() as u32;
         // 4 byte len header
         let header: [u8; 4] = unsafe { mem::transmute(len.to_be()) };
-        try!(self.sock.as_ref().unwrap().write_all(&header));
-        try!(self.sock.as_ref().unwrap().write_all(&encoded));
+        self.sock.as_ref().unwrap().write_all(&header)?;
+        self.sock.as_ref().unwrap().write_all(&encoded)?;
         self.request_num += 1;
         Ok(())
     }
 
     fn read_msg(&mut self) -> Result<ApiResponse> {
         let mut header = [0; 4];
-        try!(self.sock.as_mut().unwrap().read_exact(&mut header));
+        self.sock.as_mut().unwrap().read_exact(&mut header)?;
         let len = unsafe { u32::from_be(mem::transmute(header)) };
         let mut buf = vec![0; len as usize];
-        try!(self.sock.as_mut().unwrap().read_exact(&mut buf));
-        let mut msg: ApiMsg = try!(parse_from_bytes(&buf[..]).map_err(|e| {
-            Error::new(ErrorKind::InvalidData, e.to_string())
-        }));
+        self.sock.as_mut().unwrap().read_exact(&mut buf)?;
+        let mut msg: ApiMsg = parse_from_bytes(&buf[..])
+            .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
         Ok(msg.take_response())
     }
 }

--- a/src/bin/haret.rs
+++ b/src/bin/haret.rs
@@ -38,10 +38,9 @@ fn main() {
     // Create and start the namespace manager
     let namespace_mgr = NamespaceMgr::new(node.clone(), config.clone(), logger.clone());
     info!(logger, "Starting Namespace Manager"; "pid" => namespace_mgr.pid.to_string());
-    let mut namespace_mgr_service = Service::new(namespace_mgr.pid.clone(), node.clone(), namespace_mgr).unwrap();
-    handles.push(thread::spawn(move || {
-        namespace_mgr_service.wait();
-    }));
+    let mut namespace_mgr_service =
+        Service::new(namespace_mgr.pid.clone(), node.clone(), namespace_mgr).unwrap();
+    handles.push(thread::spawn(move || { namespace_mgr_service.wait(); }));
 
     // Create and start the admin server
     let admin_pid = Pid {
@@ -54,9 +53,7 @@ fn main() {
     let handler: TcpServerHandler<AdminConnectionHandler, MsgpackSerializer<AdminMsg>> =
         TcpServerHandler::new(admin_pid.clone(), &config.admin_host, 5000, None);
     let mut admin_service = Service::new(admin_pid, node.clone(), handler).unwrap();
-    handles.push(thread::spawn(move || {
-        admin_service.wait();
-    }));
+    handles.push(thread::spawn(move || { admin_service.wait(); }));
 
     // Create and start the API server
     let api_pid = Pid {
@@ -69,9 +66,7 @@ fn main() {
     let handler: TcpServerHandler<ApiConnectionHandler, ProtobufSerializer<ApiMsg>> =
         TcpServerHandler::new(api_pid.clone(), &config.api_host, 5000, None);
     let mut api_service = Service::new(api_pid, node.clone(), handler).unwrap();
-    handles.push(thread::spawn(move || {
-        api_service.wait();
-    }));
+    handles.push(thread::spawn(move || { api_service.wait(); }));
 
 
     for h in handles {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 
 use std::fs::File;
 use std::io::{self, Read, Write};
-use serde_json::{self};
+use serde_json;
 use error::VrError;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -33,10 +33,11 @@ impl Config {
 
     pub fn write_path(&self, path: &str) -> Result<(), VrError> {
         let mut file = File::create(path).unwrap();
-        let string = serde_json::to_string(&self).map_err(|e| io::Error::from(e))?.into_bytes();
+        let string = serde_json::to_string(&self)
+            .map_err(|e| io::Error::from(e))?
+            .into_bytes();
         file.write_all(&string).map_err(|e| e.into())
     }
-
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// This is the standard error type used throughout this crate
-/// Implementation based on suggestions in http://blog.burntsushi.net/rust-error-handling
+/// Implementation based on suggestions in
+/// http://blog.burntsushi.net/rust-error-handling
 
 use std::error::Error;
 use std::fmt;
@@ -23,9 +24,9 @@ impl Error for VrError {
         match *self {
             VrError::Io(ref string) => string,
             VrError::AlreadyExists => "resource already exists",
-            VrError::BadEncoding(_)  => "could not read encoded data",
+            VrError::BadEncoding(_) => "could not read encoded data",
             VrError::Eof => "end of file",
-            VrError::Timeout => "timeout"
+            VrError::Timeout => "timeout",
         }
     }
 }
@@ -35,10 +36,11 @@ impl fmt::Display for VrError {
         match *self {
             VrError::Io(ref string) => write!(f, "IO error: {}", string),
             VrError::AlreadyExists => write!(f, "Error: resource already exists"),
-            VrError::BadEncoding(encoding_type) => write!(f, "Could not read data encoded with {}",
-                                                          encoding_type),
+            VrError::BadEncoding(encoding_type) => {
+                write!(f, "Could not read data encoded with {}", encoding_type)
+            }
             VrError::Eof => write!(f, "Error: End Of File"),
-            VrError::Timeout => write!(f, "Error: Timeout")
+            VrError::Timeout => write!(f, "Error: Timeout"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,4 @@ mod msg;
 
 pub use msg::Msg;
 pub use namespace_mgr::NamespaceMgr;
-pub use namespace_msg::{
-    NamespaceMsg,
-    ClientId,
-    NamespaceId
-};
+pub use namespace_msg::{NamespaceMsg, ClientId, NamespaceId};

--- a/src/namespace_mgr.rs
+++ b/src/namespace_mgr.rs
@@ -30,30 +30,37 @@ pub struct NamespaceMgr {
     namespaces: Namespaces,
     /// This node's api address
     api_addr: String,
-    /// Other nodes' api addresses. Each node publishes its own configuration changes only.
+    /// Other nodes' api addresses. Each node publishes its own configuration
+    /// changes only.
     api_addrs: HashMap<NodeId, String>,
     local_replicas: HashSet<Pid>,
 
-    /**************************************************************************/
-    // It's possible these ticks will be replaced by per fsm timeouts scheduled by the FSMs
-    // themselves. For now stick to the original strategy in the old dispatcher code.
-
+    /// ************************************************************************/
+    /// It's possible these ticks will be replaced by per fsm timeouts scheduled by the FSMs
+    /// themselves. For now stick to the original strategy in the old dispatcher code.
     /// Timeout configuration for VR Fsms
     idle_timeout: Duration,
     primary_tick_ms: u64,
 
-    /// The amount of time between VrMsg::Tick messages being sent to replicas. By default this
+    /// The amount of time between VrMsg::Tick messages being sent to replicas.
+    /// By default this
     /// value is set at 1/3 * primary_tick_ms for the following reasons:
-    /// 1) We want to send timeout messages as close to the tick timeout as possible (therfore use
+    /// 1) We want to send timeout messages as close to the tick timeout as
+    /// possible (therfore use
     ///    smaller tick values)
-    /// 2) We don't want to unnecessarily spam the FSMs with ticks and chew CPU cycles (therefore
+    /// 2) We don't want to unnecessarily spam the FSMs with ticks and chew CPU
+    /// cycles (therefore
     ///    use larger tick values)
-    /// This setting allows us to maximally send a commit message 1/3 primary_tick_ms late. If we
-    /// always ensure that `idle_timeout` is at least double `primary_tick_ms` we can minimize
-    /// unnecessary view changes. Note that for backups, the ticks are higher frequency than
-    /// necessary, but this is the tradeoff made for having a single Tick message.
+    /// This setting allows us to maximally send a commit message 1/3
+    /// primary_tick_ms late. If we
+    /// always ensure that `idle_timeout` is at least double `primary_tick_ms`
+    /// we can minimize
+    /// unnecessary view changes. Note that for backups, the ticks are higher
+    /// frequency than
+    /// necessary, but this is the tradeoff made for having a single Tick
+    /// message.
     tick_period: u64,
-    /*************************************************************************/
+    /// **********************************************************************
     fsm_timer_id: usize,
     management_timer_id: usize
 }
@@ -80,7 +87,7 @@ impl NamespaceMgr {
             primary_tick_ms: DEFAULT_PRIMARY_TICK_MS,
             tick_period: DEFAULT_PRIMARY_TICK_MS / 3,
             fsm_timer_id: 0, // Dummy timer for now. Will be set in init()
-            management_timer_id: 0, // Dummy timer for now. Will be set in init()
+            management_timer_id: 0 // Dummy timer for now. Will be set in init()
         }
     }
 
@@ -118,61 +125,63 @@ impl NamespaceMgr {
         Envelope {
             to: pid,
             from: self.pid.clone(),
-            msg: rabble::Msg::User(Msg::Namespace(
-                    NamespaceMsg::Namespaces(self.namespaces.clone()))),
+            msg: rabble::Msg::User(Msg::Namespace(NamespaceMsg::Namespaces(self.namespaces
+                                                                               .clone()))),
             correlation_id: None
         }
     }
 
-    fn handle_namespace_msg(&mut self,
-                            from: Pid,
-                            msg: NamespaceMsg,
-                            c_id: Option<CorrelationId>)
-    {
+    fn handle_namespace_msg(&mut self, from: Pid, msg: NamespaceMsg, c_id: Option<CorrelationId>) {
         match msg {
-            NamespaceMsg::Namespaces(namespaces) =>
-                self.check_namespaces(namespaces),
+            NamespaceMsg::Namespaces(namespaces) => {
+                self.check_namespaces(namespaces)
+            }
             NamespaceMsg::ApiAddr(addr) => {
                 self.api_addrs.insert(from.node.clone(), addr);
             }
-            NamespaceMsg::Reconfiguration {namespace_id, old_config, new_config} =>
-                self.reconfigure(namespace_id, old_config, new_config),
-            NamespaceMsg::Stop(pid) =>
-                self.stop(&pid),
+            NamespaceMsg::Reconfiguration {
+                namespace_id,
+                old_config,
+                new_config
+            } => self.reconfigure(namespace_id, old_config, new_config),
+            NamespaceMsg::Stop(pid) => self.stop(&pid),
             NamespaceMsg::NewPrimary(pid) => {
                 let namespace_id = NamespaceId(pid.group.clone().unwrap());
                 self.namespaces.primaries.insert(namespace_id, pid);
-            },
+            }
             NamespaceMsg::ClearPrimary(namespace_id) => {
                 self.namespaces.primaries.remove(&namespace_id);
-            },
-            NamespaceMsg::RegisterClient(client_id, namespace_id) =>
+            }
+            NamespaceMsg::RegisterClient(client_id, namespace_id) => {
                 self.register_client(client_id, namespace_id, c_id.unwrap())
+            }
         }
     }
 
     // TODO: Register the client with the VR client table (once it exists).
-    fn register_client(&mut self,
-                       _: ClientId,
-                       namespace_id: NamespaceId,
-                       c_id: CorrelationId)
-    {
+    fn register_client(&mut self, _: ClientId, namespace_id: NamespaceId, c_id: CorrelationId) {
         let msg = match self.namespaces.primaries.get(&namespace_id) {
             Some(replica) => {
                 if replica.node == self.node.id {
                     // TODO: Actually return a valid new_registration value when the
                     // client table exists
-                    ApiRpy::ClientRegistration {primary: replica.clone(), new_registration: true}
+                    ApiRpy::ClientRegistration {
+                        primary: replica.clone(),
+                        new_registration: true
+                    }
                 } else {
                     match self.api_addrs.get(&replica.node) {
-                        Some(addr) =>
-                            ApiRpy::Redirect {primary: replica.clone(), api_addr: addr.clone()},
-                        None =>
-                            ApiRpy::Retry(10000)
+                        Some(addr) => {
+                            ApiRpy::Redirect {
+                                primary: replica.clone(),
+                                api_addr: addr.clone()
+                            }
+                        }
+                        None => ApiRpy::Retry(10000),
                     }
                 }
-            },
-            None => ApiRpy::UnknownNamespace
+            }
+            None => ApiRpy::UnknownNamespace,
         };
         let envelope = Envelope {
             to: c_id.pid.clone(),
@@ -189,46 +198,47 @@ impl NamespaceMgr {
             AdminReq::GetConfig => {
                 let config = self.config.clone();
                 self.send_admin_rpy(AdminRpy::Config(config), correlation_id);
-            },
+            }
             AdminReq::Join(node_id) => {
                 self.node.join(&node_id).unwrap();
                 self.send_admin_rpy(AdminRpy::Ok, correlation_id);
-            },
+            }
             AdminReq::GetNamespaces => {
                 let namespaces = self.namespaces.clone();
-                self.send_admin_rpy(AdminRpy::Namespaces(namespaces),
-                                    correlation_id);
-            },
+                self.send_admin_rpy(AdminRpy::Namespaces(namespaces), correlation_id);
+            }
             AdminReq::CreateNamespace(replicas) => {
-                let mut s: String = replicas.iter().map(|r| {
+                let mut s: String = replicas.iter()
+                                            .map(|r| {
                     let mut s = r.to_string();
                     s.push(',');
                     s
-                }).collect();
+                })
+                                            .collect();
                 s = s.trim_matches(',').to_string();
                 info!(self.logger,  "Attempt Create namespace"; "replicas" => s.clone());
                 match self.create_namespace(replicas) {
                     Ok(namespace_id) => {
                         info!(self.logger, "Namespace created"; "namespace" => namespace_id.0);
                         self.send_admin_rpy(AdminRpy::Ok, correlation_id)
-                    },
+                    }
                     Err(e) => {
                         warn!(self.logger, "Namespace failed to be created";
                               "replicas" => s, "error" => e.to_string());
                         self.send_admin_rpy(AdminRpy::Error(e.to_string()), correlation_id)
                     }
                 }
-            },
+            }
             AdminReq::GetPrimary(namespace_id) => {
                 let primary = match self.namespaces.primaries.get(&namespace_id) {
                     Some(replica) => Some(replica.clone()),
-                    None => None
+                    None => None,
                 };
                 self.send_admin_rpy(AdminRpy::Primary(primary), correlation_id);
-            },
+            }
             AdminReq::GetClusterStatus => {
                 self.node.cluster_status(correlation_id).unwrap();
-            },
+            }
             _ => {
                 self.send_admin_rpy(AdminRpy::Error("Unknown Admin Message".to_string()),
                                     correlation_id);
@@ -247,23 +257,27 @@ impl NamespaceMgr {
         self.node.send(envelope).unwrap();
     }
 
-    /// Receive a copy of current namespaces from another node and see if the local copy is
+    /// Receive a copy of current namespaces from another node and see if the
+    /// local copy is
     /// outdated. Configure them and start/stop replicas as needed.
     pub fn check_namespaces(&mut self, namespaces: Namespaces) {
-        for (namespace_id, &(ref old_config, ref new_config)) in namespaces.map.iter() {
+        for (namespace_id, &(ref old_config, ref new_config)) in
+            namespaces.map.iter() {
             if self.namespaces.exists(namespace_id) {
                 self.reconfigure(namespace_id.clone(), old_config.clone(), new_config.clone());
             } else {
-                self.namespaces.insert(namespace_id.clone(), old_config.clone(), new_config.clone());
+                self.namespaces
+                    .insert(namespace_id.clone(), old_config.clone(), new_config.clone());
                 for r in old_config.replicas.iter().chain(new_config.replicas.iter()) {
-                    self.peers.insert(Pid {
-                        group: None,
-                        name: "namespace_mgr".to_string(),
-                        node: r.node.clone()
-                    });
+                    self.peers
+                        .insert(Pid {
+                                    group: None,
+                                    name: "namespace_mgr".to_string(),
+                                    node: r.node.clone()
+                                });
                 }
                 for r in new_config.replicas.iter().cloned() {
-                    if self.node.id == r.node{
+                    if self.node.id == r.node {
                         if old_config.epoch == 0 {
                             self.start_replica_initial_config(r, new_config.clone());
                         } else {
@@ -276,17 +290,23 @@ impl NamespaceMgr {
     }
 
     fn create_namespace(&mut self, mut new_replicas: Vec<Pid>) -> rabble::Result<NamespaceId> {
-        let namespace_id = try!(validate_group_pids(&new_replicas));
+        let namespace_id = validate_group_pids(&new_replicas)?;
         new_replicas.sort();
         let old_config = VersionedReplicas::new();
-        let new_config = VersionedReplicas {epoch: 1, op: 0, replicas: new_replicas};
-        self.namespaces.insert(namespace_id.clone(), old_config.clone(), new_config.clone());
+        let new_config = VersionedReplicas {
+            epoch: 1,
+            op: 0,
+            replicas: new_replicas
+        };
+        self.namespaces
+            .insert(namespace_id.clone(), old_config.clone(), new_config.clone());
         for r in new_config.replicas.iter().cloned() {
-            self.peers.insert(Pid {
-                group: None,
-                name: "namespace_mgr".to_string(),
-                node: r.node.clone()
-            });
+            self.peers
+                .insert(Pid {
+                            group: None,
+                            name: "namespace_mgr".to_string(),
+                            node: r.node.clone()
+                        });
             if self.node.id == r.node {
                 self.start_replica_initial_config(r, new_config.clone());
             }
@@ -294,22 +314,26 @@ impl NamespaceMgr {
         Ok(namespace_id)
     }
 
-   fn reconfigure(&mut self,
-                  namespace: NamespaceId,
-                  old_config: VersionedReplicas,
-                  new_config: VersionedReplicas)
-    {
+    fn reconfigure(&mut self,
+                   namespace: NamespaceId,
+                   old_config: VersionedReplicas,
+                   new_config: VersionedReplicas) {
         let (changed, to_start) =
-            self.namespaces.reconfigure(&namespace, old_config.clone(), new_config.clone());
+            self.namespaces
+                .reconfigure(&namespace, old_config.clone(), new_config.clone());
 
         if changed {
-            self.peers = self.namespaces.nodes().iter().map(|node| {
+            self.peers = self.namespaces
+                             .nodes()
+                             .iter()
+                             .map(|node| {
                 Pid {
                     group: None,
                     name: "namespace_mgr".to_string(),
                     node: node.clone()
                 }
-            }).collect();
+            })
+                             .collect();
         }
 
         for replica in to_start {
@@ -319,35 +343,38 @@ impl NamespaceMgr {
         }
     }
 
-   fn start_replica_reconfig(&mut self,
-                             pid: &Pid,
-                             old_config: &VersionedReplicas,
-                             new_config: &VersionedReplicas) {
-       // The same reconfigure announcement can occur from multiple replicas on the same node
-       if self.local_replicas.contains(pid) { return; }
-       let mut ctx = VrCtx::new(self.logger.clone(),
-                                pid.clone(),
-                                old_config.clone(),
-                                new_config.clone());
-       ctx.idle_timeout = self.idle_timeout.clone();
-       ctx.primary_tick_ms = self.primary_tick_ms;
-       let fsm = Fsm::<VrTypes>::new(ctx, state_fn!(vr_fsm::startup_reconfiguration));
-       self.node.spawn(&pid, Box::new(Replica::new(pid.clone(), fsm))).unwrap();
-       self.local_replicas.insert(pid.clone());
-   }
+    fn start_replica_reconfig(&mut self,
+                              pid: &Pid,
+                              old_config: &VersionedReplicas,
+                              new_config: &VersionedReplicas) {
+        // The same reconfigure announcement can occur from multiple replicas on the
+        // same node
+        if self.local_replicas.contains(pid) {
+            return;
+        }
+        let mut ctx =
+            VrCtx::new(self.logger.clone(), pid.clone(), old_config.clone(), new_config.clone());
+        ctx.idle_timeout = self.idle_timeout.clone();
+        ctx.primary_tick_ms = self.primary_tick_ms;
+        let fsm = Fsm::<VrTypes>::new(ctx, state_fn!(vr_fsm::startup_reconfiguration));
+        self.node
+            .spawn(&pid, Box::new(Replica::new(pid.clone(), fsm)))
+            .unwrap();
+        self.local_replicas.insert(pid.clone());
+    }
 
 
     fn start_replica_initial_config(&mut self, pid: Pid, new_config: VersionedReplicas) {
-       println!("start pid {:?}", pid);
-       let mut ctx = VrCtx::new(self.logger.clone(),
-                                pid.clone(),
-                                VersionedReplicas::new(),
-                                new_config);
-       ctx.idle_timeout = self.idle_timeout.clone();
-       ctx.primary_tick_ms = self.primary_tick_ms;
-       let fsm = Fsm::<VrTypes>::new(ctx, state_fn!(vr_fsm::startup_new_namespace));
-       self.node.spawn(&pid, Box::new(Replica::new(pid.clone(), fsm))).unwrap();
-       self.local_replicas.insert(pid);
+        println!("start pid {:?}", pid);
+        let mut ctx =
+            VrCtx::new(self.logger.clone(), pid.clone(), VersionedReplicas::new(), new_config);
+        ctx.idle_timeout = self.idle_timeout.clone();
+        ctx.primary_tick_ms = self.primary_tick_ms;
+        let fsm = Fsm::<VrTypes>::new(ctx, state_fn!(vr_fsm::startup_new_namespace));
+        self.node
+            .spawn(&pid, Box::new(Replica::new(pid.clone(), fsm)))
+            .unwrap();
+        self.local_replicas.insert(pid);
     }
 
     /// Should only be called outside this module during tests
@@ -358,42 +385,54 @@ impl NamespaceMgr {
 
     /// Should only be called outside this module during tests
     pub fn restart(&mut self, pid: Pid) {
-       let namespace_id = NamespaceId(pid.group.clone().unwrap());
-       if let Some((old_config, new_config)) = self.namespaces.get_config(&namespace_id) {
-           let mut ctx = VrCtx::new(self.logger.clone(),
-                                    pid.clone(),
-                                    old_config.clone(),
-                                    new_config.clone());
-           ctx.idle_timeout = self.idle_timeout.clone();
-           ctx.primary_tick_ms = self.primary_tick_ms;
-           let fsm = Fsm::<VrTypes>::new(ctx, state_fn!(vr_fsm::startup_recovery));
-           self.node.spawn(&pid, Box::new(Replica::new(pid.clone(), fsm))).unwrap();
-           self.local_replicas.insert(pid);
-       }
+        let namespace_id = NamespaceId(pid.group.clone().unwrap());
+        if let Some((old_config, new_config)) =
+            self.namespaces.get_config(&namespace_id) {
+            let mut ctx = VrCtx::new(self.logger.clone(),
+                                     pid.clone(),
+                                     old_config.clone(),
+                                     new_config.clone());
+            ctx.idle_timeout = self.idle_timeout.clone();
+            ctx.primary_tick_ms = self.primary_tick_ms;
+            let fsm = Fsm::<VrTypes>::new(ctx, state_fn!(vr_fsm::startup_recovery));
+            self.node
+                .spawn(&pid, Box::new(Replica::new(pid.clone(), fsm)))
+                .unwrap();
+            self.local_replicas.insert(pid);
+        }
     }
 }
 
 impl ServiceHandler<Msg> for NamespaceMgr {
     fn init(&mut self, registrar: &Registrar, _: &Node<Msg>) -> rabble::Result<()> {
-        self.fsm_timer_id = try!(registrar.set_interval(self.tick_period as usize)
-                              .chain_err(|| "Failed to register request timer"));
-        self.management_timer_id = try!(registrar.set_interval(MANAGEMENT_TICK_MS as usize)
-                                     .chain_err(|| "Failed to register request timer"));
+        self.fsm_timer_id =
+            registrar.set_interval(self.tick_period as usize)
+                     .chain_err(|| "Failed to register request timer")?;
+        self.management_timer_id =
+            registrar.set_interval(MANAGEMENT_TICK_MS as usize)
+                     .chain_err(|| "Failed to register request timer")?;
         Ok(())
     }
 
     fn handle_envelope(&mut self,
                        _: &Node<Msg>,
                        envelope: Envelope<Msg>,
-                       _: &Registrar) -> rabble::Result<()>
-    {
-        let Envelope{from, msg, correlation_id, ..} = envelope;
+                       _: &Registrar)
+                       -> rabble::Result<()> {
+        let Envelope {
+            from,
+            msg,
+            correlation_id,
+            ..
+        } = envelope;
         match msg {
-            rabble::Msg::User(Msg::AdminReq(req)) =>
-                self.handle_admin_req(req, correlation_id),
-            rabble::Msg::User(Msg::Namespace(msg)) =>
-                self.handle_namespace_msg(from, msg, correlation_id),
-            _ => unreachable!()
+            rabble::Msg::User(Msg::AdminReq(req)) => {
+                self.handle_admin_req(req, correlation_id)
+            }
+            rabble::Msg::User(Msg::Namespace(msg)) => {
+                self.handle_namespace_msg(from, msg, correlation_id)
+            }
+            _ => unreachable!(),
         }
 
         Ok(())
@@ -403,8 +442,8 @@ impl ServiceHandler<Msg> for NamespaceMgr {
     fn handle_notification(&mut self,
                            _: &Node<Msg>,
                            notification: Notification,
-                           _: &Registrar) -> rabble::Result<()>
-    {
+                           _: &Registrar)
+                           -> rabble::Result<()> {
 
         if notification.id == self.fsm_timer_id {
             self.fsm_tick();
@@ -419,7 +458,8 @@ impl ServiceHandler<Msg> for NamespaceMgr {
     }
 }
 
-/// Ensure all pids have an identical `group` value and that group value is not `None`
+/// Ensure all pids have an identical `group` value and that group value is not
+/// `None`
 fn validate_group_pids(pids: &Vec<Pid>) -> rabble::Result<NamespaceId> {
     let mut namespace_id = None;
     for pid in pids {
@@ -431,7 +471,7 @@ fn validate_group_pids(pids: &Vec<Pid>) -> rabble::Result<NamespaceId> {
                 if namespace_id.is_none() {
                     namespace_id = Some(NamespaceId(s.to_string()));
                 }
-            },
+            }
             None => {
                 return Err("All pids in a group must have a group ID".into());
             }
@@ -439,4 +479,3 @@ fn validate_group_pids(pids: &Vec<Pid>) -> rabble::Result<NamespaceId> {
     }
     Ok(namespace_id.unwrap())
 }
-

--- a/src/namespace_msg.rs
+++ b/src/namespace_msg.rs
@@ -19,10 +19,12 @@ pub enum NamespaceMsg {
     /// Register a client with the primary of a namespace
     RegisterClient(ClientId, NamespaceId),
 
-    /// API Addresses are published from the node they live on to all other nodes.
+    /// API Addresses are published from the node they live on to all other
+    /// nodes.
     ApiAddr(String),
 
-    /// The following four messages are sent from a VM to indicate a change in membership state for
+    /// The following four messages are sent from a VM to indicate a change in
+    /// membership state for
     /// a given namespace
     Reconfiguration {
         namespace_id: NamespaceId,
@@ -33,4 +35,3 @@ pub enum NamespaceMsg {
     NewPrimary(Pid),
     ClearPrimary(NamespaceId)
 }
-

--- a/src/namespaces.rs
+++ b/src/namespaces.rs
@@ -25,14 +25,21 @@ impl Namespaces {
     /// Note that this can be expensive with a large number of namespaces.
     /// However, It's only used during an actual reconfiguration.
     pub fn nodes(&self) -> HashSet<NodeId> {
-        self.map.iter().flat_map(|(_, &(ref old_config, ref new_config))| {
-            old_config.replicas.iter().chain(new_config.replicas.iter()).map(|r| {
-                r.node.clone()
-            })
-        }).collect()
+        self.map
+            .iter()
+            .flat_map(|(_, &(ref old_config, ref new_config))| {
+            old_config.replicas
+                      .iter()
+                      .chain(new_config.replicas.iter())
+                      .map(|r| r.node.clone())
+        })
+            .collect()
     }
 
-    pub fn insert(&mut self, namespace: NamespaceId, old: VersionedReplicas, new: VersionedReplicas) {
+    pub fn insert(&mut self,
+                  namespace: NamespaceId,
+                  old: VersionedReplicas,
+                  new: VersionedReplicas) {
         self.map.insert(namespace, (old, new));
     }
 
@@ -40,28 +47,34 @@ impl Namespaces {
         self.map.contains_key(namespace)
     }
 
-    pub fn get_config(&self, namespace: &NamespaceId) -> Option<(VersionedReplicas, VersionedReplicas)> {
+    pub fn get_config(&self,
+                      namespace: &NamespaceId)
+                      -> Option<(VersionedReplicas, VersionedReplicas)> {
         match self.map.get(&namespace) {
-            Some(&(ref old_config, ref new_config)) =>
-                Some((old_config.clone(), new_config.clone())),
-            None => None
+            Some(&(ref old_config, ref new_config)) => {
+                Some((old_config.clone(), new_config.clone()))
+            }
+            None => None,
         }
     }
 
-    /// Save the new namespace configuration and return whether there actually was a configuration
+    /// Save the new namespace configuration and return whether there actually
+    /// was a configuration
     /// change as well as the new replicas that need starting.
     pub fn reconfigure(&mut self,
                        namespace: &NamespaceId,
                        old: VersionedReplicas,
-                       new: VersionedReplicas) -> (bool, Vec<Pid>)
-    {
-        if let Some(&mut(ref mut saved_old_config, ref mut saved_new_config)) =
-            self.map.get_mut(&namespace)
-        {
+                       new: VersionedReplicas)
+                       -> (bool, Vec<Pid>) {
+        if let Some(&mut (ref mut saved_old_config, ref mut saved_new_config)) =
+            self.map.get_mut(&namespace) {
             // This is an old reconfig message, nothing to start
-            if new.epoch <= saved_new_config.epoch { return (false, Vec::new()) }
+            if new.epoch <= saved_new_config.epoch {
+                return (false, Vec::new());
+            }
             let new_set = HashSet::<Pid>::from_iter(new.replicas.clone());
-            // We want to use the actual running nodes here because we are trying to determine which
+            // We want to use the actual running nodes here because we are trying to
+            // determine which
             // nodes to start locally
             let old_set = HashSet::<Pid>::from_iter(saved_new_config.replicas.clone());
             let to_start: Vec<Pid> = new_set.difference(&old_set).cloned().collect();

--- a/src/vr/backend.rs
+++ b/src/vr/backend.rs
@@ -13,9 +13,7 @@ pub struct VrBackend {
 
 impl VrBackend {
     pub fn new() -> VrBackend {
-        VrBackend {
-            tree: Tree::new()
-        }
+        VrBackend { tree: Tree::new() }
     }
 
     pub fn call(&mut self, msg: VrApiReq) -> VrApiRsp {
@@ -23,13 +21,13 @@ impl VrBackend {
             VrApiReq::TreeOp(tree_op) => {
                 match self.run_tree_op(tree_op) {
                     Ok(vr_api_rsp) => vr_api_rsp,
-                    Err(vertree_error) => vertree_error.into()
+                    Err(vertree_error) => vertree_error.into(),
                 }
-            },
+            }
             VrApiReq::TreeCas(tree_cas) => {
                 match self.run_tree_cas(tree_cas) {
                     Ok(vr_api_rsp) => vr_api_rsp,
-                    Err(vertree_error) => vertree_error.into()
+                    Err(vertree_error) => vertree_error.into(),
                 }
             }
         }
@@ -37,102 +35,102 @@ impl VrBackend {
 
     fn run_tree_op(&mut self, tree_op: TreeOp) -> Result<VrApiRsp, vertree::Error> {
         let val = match tree_op {
-            TreeOp::Snapshot {directory} => {
-                let s = try!(self.tree.snapshot(&directory));
+            TreeOp::Snapshot { directory } => {
+                let s = self.tree.snapshot(&directory)?;
                 VrApiRsp::Path(s)
-            },
-            TreeOp::CreateNode {path, ty} => {
-                self.tree = try!(self.tree.create(&path, ty.into()));
+            }
+            TreeOp::CreateNode { path, ty } => {
+                self.tree = self.tree.create(&path, ty.into())?;
                 VrApiRsp::Ok
-            },
-            TreeOp::DeleteNode {path} => {
-                let (_, tree) = try!(self.tree.delete(&path));
+            }
+            TreeOp::DeleteNode { path } => {
+                let (_, tree) = self.tree.delete(&path)?;
                 self.tree = tree;
                 VrApiRsp::Ok
-            },
-            TreeOp::ListKeys {..} => {
+            }
+            TreeOp::ListKeys { .. } => {
                 // Use the path variable when vertree supports it
                 VrApiRsp::TreeOpResult(TreeOpResult::Keys(self.tree.keys()))
-            },
-            TreeOp::BlobPut {path, val} => {
-                let (reply, tree) = try!(self.tree.blob_put(path, val));
+            }
+            TreeOp::BlobPut { path, val } => {
+                let (reply, tree) = self.tree.blob_put(path, val)?;
                 self.tree = tree;
                 reply.into()
-            },
-            TreeOp::BlobGet {path} => {
-                let reply = try!(self.tree.blob_get(path));
+            }
+            TreeOp::BlobGet { path } => {
+                let reply = self.tree.blob_get(path)?;
                 reply.into()
-            },
-            TreeOp::BlobSize {path} => {
-                let reply = try!(self.tree.blob_size(path));
+            }
+            TreeOp::BlobSize { path } => {
+                let reply = self.tree.blob_size(path)?;
                 reply.into()
-            },
-            TreeOp::QueuePush {path, val} => {
-                let (reply, tree) = try!(self.tree.queue_push(path, val));
+            }
+            TreeOp::QueuePush { path, val } => {
+                let (reply, tree) = self.tree.queue_push(path, val)?;
                 self.tree = tree;
                 reply.into()
-            },
-            TreeOp::QueuePop {path} => {
-                let (reply, tree) = try!(self.tree.queue_pop(path));
+            }
+            TreeOp::QueuePop { path } => {
+                let (reply, tree) = self.tree.queue_pop(path)?;
                 self.tree = tree;
                 reply.into()
-            },
-            TreeOp::QueueFront {path} => {
-                let reply = try!(self.tree.queue_front(path));
+            }
+            TreeOp::QueueFront { path } => {
+                let reply = self.tree.queue_front(path)?;
                 reply.into()
-            },
-            TreeOp::QueueBack {path} => {
-                let reply = try!(self.tree.queue_back(path));
+            }
+            TreeOp::QueueBack { path } => {
+                let reply = self.tree.queue_back(path)?;
                 reply.into()
-            },
-            TreeOp::QueueLen {path} => {
-                let reply = try!(self.tree.queue_len(path));
+            }
+            TreeOp::QueueLen { path } => {
+                let reply = self.tree.queue_len(path)?;
                 reply.into()
-            },
-            TreeOp::SetInsert {path, val} => {
-                let (reply, tree) = try!(self.tree.set_insert(path, val));
+            }
+            TreeOp::SetInsert { path, val } => {
+                let (reply, tree) = self.tree.set_insert(path, val)?;
                 self.tree = tree;
                 reply.into()
-            },
-            TreeOp::SetRemove {path, val} => {
-                let (reply, tree) = try!(self.tree.set_remove(path, val));
+            }
+            TreeOp::SetRemove { path, val } => {
+                let (reply, tree) = self.tree.set_remove(path, val)?;
                 self.tree = tree;
                 reply.into()
-            },
-            TreeOp::SetContains {path, val} => {
-                let reply= try!(self.tree.set_contains(path, val));
+            }
+            TreeOp::SetContains { path, val } => {
+                let reply = self.tree.set_contains(path, val)?;
                 reply.into()
-            },
-            TreeOp::SetUnion {paths, sets} => {
-                let reply = try!(self.tree.set_union(paths, sets));
+            }
+            TreeOp::SetUnion { paths, sets } => {
+                let reply = self.tree.set_union(paths, sets)?;
                 reply.into()
-            },
-            TreeOp::SetIntersection {path1, path2} => {
-                let reply = try!(self.tree.set_intersection(&path1, &path2));
+            }
+            TreeOp::SetIntersection { path1, path2 } => {
+                let reply = self.tree.set_intersection(&path1, &path2)?;
                 reply.into()
-            },
-            TreeOp::SetDifference {path1, path2} => {
-                let reply = try!(self.tree.set_difference(&path1, &path2));
+            }
+            TreeOp::SetDifference { path1, path2 } => {
+                let reply = self.tree.set_difference(&path1, &path2)?;
                 reply.into()
-            },
-            TreeOp::SetSymmetricDifference {path1, path2} => {
-                let reply = try!(self.tree.set_symmetric_difference(&path1, &path2));
+            }
+            TreeOp::SetSymmetricDifference { path1, path2 } => {
+                let reply = self.tree.set_symmetric_difference(&path1, &path2)?;
                 reply.into()
-            },
-            TreeOp::SetSubsetPath {path1, path2} => {
-                let reply = try!(self.tree.set_subset(path1, Some(path2), None));
+            }
+            TreeOp::SetSubsetPath { path1, path2 } => {
+                let reply = self.tree.set_subset(path1, Some(path2), None)?;
                 reply.into()
-            },
-            TreeOp::SetSubsetSet {path,  set} => {
-                let reply = try!(self.tree.set_subset(path, None, Some(set)));
+            }
+            TreeOp::SetSubsetSet { path, set } => {
+                let reply = self.tree.set_subset(path, None, Some(set))?;
                 reply.into()
-            },
-            TreeOp::SetSupersetPath {path1, path2} => {
-                let reply = try!(self.tree.set_superset(path1, Some(path2), None));
+            }
+            TreeOp::SetSupersetPath { path1, path2 } => {
+                let reply = self.tree.set_superset(path1, Some(path2), None)?;
                 reply.into()
-            },
-            TreeOp::SetSupersetSet {path, set} => {
-                let reply = try!(self.tree.set_subset(path, None, Some(set)));
+            }
+            TreeOp::SetSupersetSet { path, set } => {
+                let reply = self.tree.set_subset(path, None, Some(set))?;
                 reply.into()
             }
         };
@@ -140,16 +138,21 @@ impl VrBackend {
     }
 
     fn run_tree_cas(&mut self, tree_cas: TreeCas) -> Result<VrApiRsp, vertree::Error> {
-        let TreeCas {guards, ops} = tree_cas;
+        let TreeCas { guards, ops } = tree_cas;
         // All cas operations must be writes for now
         if ops.iter().any(|s| !s.is_write()) {
             let err = VrApiError::InvalidCas("All cas operations must be writes".to_string());
-            // Returning Ok here because we already have a VrApiRsp (even though it's an error)
+            // Returning Ok here because we already have a VrApiRsp (even though it's an
+            // error)
             return Ok(VrApiRsp::Error(err));
         }
-        let guards = guards.into_iter().map(|g| vertree::Guard::from(g)).collect();
-        let ops = ops.into_iter().map(|op| vertree::WriteOp::from(op)).collect();
-        let (replies, tree) = try!(self.tree.multi_cas(guards, ops));
+        let guards = guards.into_iter()
+                           .map(|g| vertree::Guard::from(g))
+                           .collect();
+        let ops = ops.into_iter()
+                     .map(|op| vertree::WriteOp::from(op))
+                     .collect();
+        let (replies, tree) = self.tree.multi_cas(guards, ops)?;
         self.tree = tree;
         let replies = replies.into_iter().map(|r| r.into()).collect();
         Ok(VrApiRsp::TreeCasResult(replies))
@@ -159,15 +162,40 @@ impl VrBackend {
 impl From<TreeOp> for vertree::WriteOp {
     fn from(op: TreeOp) -> vertree::WriteOp {
         match op {
-            TreeOp::Snapshot {directory} => vertree::WriteOp::Snapshot {directory: directory},
-            TreeOp::CreateNode {path, ty} => vertree::WriteOp::CreateNode {path: path, ty: ty.into()},
-            TreeOp::DeleteNode {path} => vertree::WriteOp::DeleteNode {path: path},
-            TreeOp::BlobPut {path, val} => vertree::WriteOp::BlobPut {path: path, val: val},
-            TreeOp::QueuePush {path, val} => vertree::WriteOp::QueuePush {path: path, val: val},
-            TreeOp::QueuePop {path} => vertree::WriteOp::QueuePop {path: path},
-            TreeOp::SetInsert {path, val} => vertree::WriteOp::SetInsert {path: path, val: val},
-            TreeOp::SetRemove {path, val} => vertree::WriteOp::SetRemove {path: path, val: val},
-            _ => unreachable!()
+            TreeOp::Snapshot { directory } => vertree::WriteOp::Snapshot { directory: directory },
+            TreeOp::CreateNode { path, ty } => {
+                vertree::WriteOp::CreateNode {
+                    path: path,
+                    ty: ty.into()
+                }
+            }
+            TreeOp::DeleteNode { path } => vertree::WriteOp::DeleteNode { path: path },
+            TreeOp::BlobPut { path, val } => {
+                vertree::WriteOp::BlobPut {
+                    path: path,
+                    val: val
+                }
+            }
+            TreeOp::QueuePush { path, val } => {
+                vertree::WriteOp::QueuePush {
+                    path: path,
+                    val: val
+                }
+            }
+            TreeOp::QueuePop { path } => vertree::WriteOp::QueuePop { path: path },
+            TreeOp::SetInsert { path, val } => {
+                vertree::WriteOp::SetInsert {
+                    path: path,
+                    val: val
+                }
+            }
+            TreeOp::SetRemove { path, val } => {
+                vertree::WriteOp::SetRemove {
+                    path: path,
+                    val: val
+                }
+            }
+            _ => unreachable!(),
         }
     }
 }
@@ -178,7 +206,7 @@ impl From<NodeType> for vertree::NodeType {
             NodeType::Blob => vertree::NodeType::Blob,
             NodeType::Queue => vertree::NodeType::Queue,
             NodeType::Set => vertree::NodeType::Set,
-            NodeType::Directory => vertree::NodeType::Directory
+            NodeType::Directory => vertree::NodeType::Directory,
         }
     }
 }
@@ -187,9 +215,9 @@ impl From<vertree::NodeType> for NodeType {
     fn from(n: vertree::NodeType) -> NodeType {
         match n {
             vertree::NodeType::Blob => NodeType::Blob,
-            vertree::NodeType::Queue =>NodeType::Queue,
+            vertree::NodeType::Queue => NodeType::Queue,
             vertree::NodeType::Set => NodeType::Set,
-            vertree::NodeType::Directory => NodeType::Directory
+            vertree::NodeType::Directory => NodeType::Directory,
         }
     }
 }
@@ -206,14 +234,14 @@ impl From<Guard> for vertree::Guard {
 
 impl From<vertree::Reply> for TreeOpResult {
     fn from(reply: vertree::Reply) -> TreeOpResult {
-        let vertree::Reply {version, value, ..} = reply;
+        let vertree::Reply { version, value, .. } = reply;
         match value {
             Value::Blob(vec) => TreeOpResult::Blob(vec, version),
             Value::Set(set) => TreeOpResult::Set(set.data.into_iter().collect(), version),
             Value::Int(i) => TreeOpResult::Int(i, version),
             Value::Bool(b) => TreeOpResult::Bool(b, version),
             Value::Empty => TreeOpResult::Empty(version),
-            Value::None => TreeOpResult::Ok(version)
+            Value::None => TreeOpResult::Ok(version),
         }
     }
 }
@@ -231,15 +259,24 @@ impl From<vertree::Error> for VrApiRsp {
             ErrorKind::DoesNotExist(path) => VrApiError::DoesNotExist(path),
             ErrorKind::WrongType(path, ty) => VrApiError::WrongType(path, ty.into()),
             ErrorKind::InvalidPathContent(path) => VrApiError::PathMustEndInDirectory(path),
-            ErrorKind::CasFailed{path, expected, actual} =>
-                VrApiError::CasFailed {path: path, expected: expected, actual: actual},
+            ErrorKind::CasFailed {
+                path,
+                expected,
+                actual
+            } => {
+                VrApiError::CasFailed {
+                    path: path,
+                    expected: expected,
+                    actual: actual
+                }
+            }
             ErrorKind::BadPath(msg) => VrApiError::BadFormat(msg),
             ErrorKind::Io(e) => VrApiError::Io(e.to_string()),
             ErrorKind::MsgPackValueReadError(e) => VrApiError::EncodingError(e.to_string()),
             ErrorKind::MsgPackValueWriteError(e) => VrApiError::EncodingError(e.to_string()),
             ErrorKind::CannotDeleteRoot => VrApiError::CannotDeleteRoot,
             ErrorKind::PathMustBeAbsolute(path) => VrApiError::PathMustBeAbsolute(path),
-            ErrorKind::Msg(msg) => VrApiError::Msg(msg)
+            ErrorKind::Msg(msg) => VrApiError::Msg(msg),
         };
         VrApiRsp::Error(err)
     }

--- a/src/vr/fsm_output.rs
+++ b/src/vr/fsm_output.rs
@@ -12,18 +12,24 @@ pub enum FsmOutput {
     Announcement(NamespaceMsg, Pid)
 }
 
-/// Convert from FsmOuptput to Envelope with "self.into()" or Envelope::from(self)
+/// Convert from FsmOuptput to Envelope with "self.into()" or
+/// Envelope::from(self)
 impl From<FsmOutput> for Envelope<Msg> {
     fn from(fsm_output: FsmOutput) -> Envelope<Msg> {
         match fsm_output {
             FsmOutput::Vr(vr_envelope) => vr_envelope.into(),
-            FsmOutput::Announcement(namespace_msg, pid) => Envelope {
-                to: Pid {group: None, name: "namespace_mgr".to_string(), node: pid.node.clone()},
-                from: pid.clone(),
-                msg: rabble::Msg::User(Msg::Namespace(namespace_msg)),
-                correlation_id: Some(CorrelationId::pid(pid))
+            FsmOutput::Announcement(namespace_msg, pid) => {
+                Envelope {
+                    to: Pid {
+                        group: None,
+                        name: "namespace_mgr".to_string(),
+                        node: pid.node.clone()
+                    },
+                    from: pid.clone(),
+                    msg: rabble::Msg::User(Msg::Namespace(namespace_msg)),
+                    correlation_id: Some(CorrelationId::pid(pid))
+                }
             }
         }
     }
 }
-

--- a/src/vr/mod.rs
+++ b/src/vr/mod.rs
@@ -16,34 +16,19 @@ mod vr_ctx_summary;
 pub mod vr_fsm;
 pub mod vr_ctx;
 
-pub use self::vr_fsm::{
-    VrTypes
-};
+pub use self::vr_fsm::VrTypes;
 
-pub use self::vr_ctx::{
-    VrCtx
-};
+pub use self::vr_ctx::VrCtx;
 
 pub use self::vr_ctx_summary::VrCtxSummary;
 
-pub use self::replica::{
-    Replica,
-    VersionedReplicas
-};
+pub use self::replica::{Replica, VersionedReplicas};
 
 pub use self::vrmsg::VrMsg;
 pub use self::vr_envelope::VrEnvelope;
 pub use self::fsm_output::FsmOutput;
 
-pub use self::vr_api_messages::{
-    VrApiReq,
-    VrApiRsp,
-    VrApiError,
-    TreeOp,
-    TreeCas,
-    NodeType,
-    Guard,
-    TreeOpResult
-};
+pub use self::vr_api_messages::{VrApiReq, VrApiRsp, VrApiError, TreeOp, TreeCas, NodeType, Guard,
+                                TreeOpResult};
 
 pub use self::backend::VrBackend;

--- a/src/vr/prepare_requests.rs
+++ b/src/vr/prepare_requests.rs
@@ -26,12 +26,12 @@ pub struct PrepareRequests {
 }
 
 impl PrepareRequests {
-    pub fn new(num_replicas: usize, timeout_ms: u64 ) -> PrepareRequests {
+    pub fn new(num_replicas: usize, timeout_ms: u64) -> PrepareRequests {
         PrepareRequests {
-            quorum_size: num_replicas/2 + 1,
+            quorum_size: num_replicas / 2 + 1,
             timeout_ms: timeout_ms as i64,
             lowest_op: 1,
-            requests: VecDeque::new(),
+            requests: VecDeque::new()
         }
     }
 
@@ -39,11 +39,12 @@ impl PrepareRequests {
         if self.requests.is_empty() {
             self.lowest_op = op;
         }
-        self.requests.push_back(Request {
-            replies: HashSet::with_capacity(self.quorum_size * 2),
-            correlation_id: correlation_id,
-            timeout: SteadyTime::now() + Duration::milliseconds(self.timeout_ms)
-        });
+        self.requests
+            .push_back(Request {
+                           replies: HashSet::with_capacity(self.quorum_size * 2),
+                           correlation_id: correlation_id,
+                           timeout: SteadyTime::now() + Duration::milliseconds(self.timeout_ms)
+                       });
     }
 
     // Returns true if the request exists, false otherwise
@@ -53,8 +54,8 @@ impl PrepareRequests {
                 Some(ref mut request) => {
                     request.replies.insert(replica);
                     return true;
-                },
-                None => return false
+                }
+                None => return false,
             }
         }
         false
@@ -75,13 +76,15 @@ impl PrepareRequests {
     pub fn remove(&mut self, op: u64) -> Vec<Request> {
         let lowest_op = self.lowest_op;
         self.lowest_op = op + 1;
-        self.requests.drain(0..(op - lowest_op + 1) as usize).collect()
+        self.requests
+            .drain(0..(op - lowest_op + 1) as usize)
+            .collect()
     }
 
     pub fn expired(&self) -> bool {
         match self.requests.front() {
             Some(request) => request.timeout > SteadyTime::now(),
-            None => false
+            None => false,
         }
     }
 }

--- a/src/vr/quorum_tracker.rs
+++ b/src/vr/quorum_tracker.rs
@@ -15,7 +15,7 @@ pub struct QuorumTracker<T> {
 
 /// Do we have a quorum when including the replica making the request?
 impl<T> QuorumTracker<T> {
-   pub fn new(quorum_size: usize, timeout: &Duration) -> QuorumTracker<T> {
+    pub fn new(quorum_size: usize, timeout: &Duration) -> QuorumTracker<T> {
         QuorumTracker {
             quorum_size: quorum_size,
             expiration: SteadyTime::now() + *timeout,

--- a/src/vr/recovery_state.rs
+++ b/src/vr/recovery_state.rs
@@ -21,7 +21,7 @@ pub struct RecoveryState {
     pub nonce: Uuid,
     // Primary from the latest view we've heard from
     pub primary: Option<RecoveryPrimary>,
-    pub responses: QuorumTracker<()>,
+    pub responses: QuorumTracker<()>
 }
 
 impl RecoveryState {
@@ -34,8 +34,9 @@ impl RecoveryState {
     }
 
     pub fn has_quorum(&self, current_view: u64) -> bool {
-        self.responses.has_super_quorum() && self.primary.as_ref().map_or(false, |p| p.view == current_view)
+        self.responses.has_super_quorum() &&
+        self.primary
+            .as_ref()
+            .map_or(false, |p| p.view == current_view)
     }
 }
-
-

--- a/src/vr/replica.rs
+++ b/src/vr/replica.rs
@@ -10,7 +10,8 @@ use super::vrmsg::VrMsg;
 use super::vr_ctx_summary::VrCtxSummary;
 use super::super::admin::{AdminReq, AdminRpy};
 
-/// A replica wraps a VR FSM as a process so that it can receive messsages from inside rabble
+/// A replica wraps a VR FSM as a process so that it can receive messsages from
+/// inside rabble
 /// It also takes care to only pass messages of type VrEnvelope to the FSM.
 pub struct Replica {
     pid: Pid,
@@ -19,10 +20,7 @@ pub struct Replica {
 
 impl Replica {
     pub fn new(pid: Pid, fsm: Fsm<VrTypes>) -> Replica {
-        Replica {
-            pid: pid,
-            fsm: fsm
-        }
+        Replica { pid: pid, fsm: fsm }
     }
 }
 
@@ -31,15 +29,18 @@ impl Process<Msg> for Replica {
         let c_id = CorrelationId::pid(self.pid.clone());
         let envelope = VrEnvelope::new(self.pid.clone(), from, VrMsg::Tick, c_id);
         // Convert Vec<FsmOuput> to Vec<Envelope<Msg>>
-        self.fsm.send(envelope).into_iter().map(|e| e.into()).collect()
+        self.fsm
+            .send(envelope)
+            .into_iter()
+            .map(|e| e.into())
+            .collect()
     }
 
     fn handle(&mut self,
               msg: rabble::Msg<Msg>,
               from: Pid,
               correlation_id: Option<CorrelationId>,
-              output: &mut Vec<Envelope<Msg>>)
-    {
+              output: &mut Vec<Envelope<Msg>>) {
         let correlation_id = correlation_id.map_or(CorrelationId::pid(self.pid.clone()),
                                                    |c_id| c_id);
         match msg {
@@ -50,11 +51,11 @@ impl Process<Msg> for Replica {
                 let msg = rabble::Msg::User(Msg::AdminRpy(rpy));
                 let envelope = Envelope::new(from, self.pid.clone(), msg, Some(correlation_id));
                 output.push(envelope);
-            },
+            }
             rabble::Msg::User(Msg::Vr(vrmsg)) => {
-               let vr_envelope = VrEnvelope::new(self.pid.clone(), from, vrmsg, correlation_id);
-               output.extend(self.fsm.send(vr_envelope).into_iter().map(|e| e.into()));
-            },
+                let vr_envelope = VrEnvelope::new(self.pid.clone(), from, vrmsg, correlation_id);
+                output.extend(self.fsm.send(vr_envelope).into_iter().map(|e| e.into()));
+            }
             _ => {
                 let msg = rabble::Msg::User(Msg::Error("Invalid Msg Received".to_string()));
                 let envelope = Envelope::new(from, self.pid.clone(), msg, Some(correlation_id));
@@ -62,12 +63,13 @@ impl Process<Msg> for Replica {
             }
         }
     }
-
 }
 
 
-/// When we create a namesapce, the initial group of replicas is at epoch 1. When a reconfiguration
-/// occurs we bump the epoch so when we gossip the information around to start the fsms, we can
+/// When we create a namesapce, the initial group of replicas is at epoch 1.
+/// When a reconfiguration
+/// occurs we bump the epoch so when we gossip the information around to start
+/// the fsms, we can
 /// chose the latest version.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VersionedReplicas {

--- a/src/vr/view_change_state.rs
+++ b/src/vr/view_change_state.rs
@@ -27,7 +27,7 @@ impl Latest {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ViewChangeState {
     pub responses: QuorumTracker<VrMsg>,
-    latest: Latest,
+    latest: Latest
 }
 
 impl ViewChangeState {
@@ -43,32 +43,38 @@ impl ViewChangeState {
     }
 
     pub fn compute_latest_state(&mut self, current: Latest) -> Latest {
-        self.responses.drain()
+        self.responses
+            .drain()
             .map(|(_, msg)| convert_do_view_change_msg_to_latest(msg))
             .fold(current, |mut latest, other| {
-                if (other.last_normal_view > latest.last_normal_view) ||
-                    (other.last_normal_view == latest.last_normal_view && other.op > latest.op)
-                {
-                   latest.last_normal_view = other.last_normal_view;
-                   latest.op = other.op;
-                   latest.log = other.log;
-                }
-                if other.commit_num > latest.commit_num {
-                    latest.commit_num = other.commit_num;
-                }
-                latest
-            })
+            if (other.last_normal_view > latest.last_normal_view) ||
+               (other.last_normal_view == latest.last_normal_view && other.op > latest.op) {
+                latest.last_normal_view = other.last_normal_view;
+                latest.op = other.op;
+                latest.log = other.log;
+            }
+            if other.commit_num > latest.commit_num {
+                latest.commit_num = other.commit_num;
+            }
+            latest
+        })
     }
 }
 
 fn convert_do_view_change_msg_to_latest(msg: VrMsg) -> Latest {
-    if let VrMsg::DoViewChange{op, last_normal_view, commit_num, log, ..} = msg {
+    if let VrMsg::DoViewChange {
+               op,
+               last_normal_view,
+               commit_num,
+               log,
+               ..
+           } = msg {
         return Latest {
-            last_normal_view: last_normal_view,
-            commit_num: commit_num,
-            op: op,
-            log: log
-        };
+                   last_normal_view: last_normal_view,
+                   commit_num: commit_num,
+                   op: op,
+                   log: log
+               };
     }
     unreachable!()
 }

--- a/src/vr/vr_api_messages.rs
+++ b/src/vr/vr_api_messages.rs
@@ -16,50 +16,53 @@ pub enum NodeType {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum VrApiReq {
     TreeOp(TreeOp),
-    TreeCas(TreeCas),
+    TreeCas(TreeCas)
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-// This should maintain the identical format to the vertree version. The only 
+// This should maintain the identical format to the vertree version. The only
 // difference is that the haret one is encodable and decodable
 pub enum TreeOp {
-    Snapshot {directory: String},
-    CreateNode {path: String, ty: NodeType},
-    DeleteNode {path: String},
-    ListKeys {path: String},
-    BlobPut {path: String, val: Vec<u8>},
-    BlobGet {path: String},
-    BlobSize {path: String},
-    QueuePush {path: String, val: Vec<u8>},
-    QueuePop {path: String},
-    QueueFront {path: String},
-    QueueBack {path: String},
-    QueueLen {path: String},
-    SetInsert {path: String, val: Vec<u8>},
-    SetRemove {path: String, val: Vec<u8>},
-    SetContains {path: String, val: Vec<u8>},
-    SetUnion {paths: Vec<String>, sets: Vec<HashSet<Vec<u8>>>},
-    SetIntersection {path1: String, path2: String},
-    SetDifference {path1: String, path2: String},
-    SetSymmetricDifference {path1: String, path2: String},
-    SetSubsetPath {path1: String, path2: String},
-    SetSubsetSet {path: String,  set: HashSet<Vec<u8>>},
-    SetSupersetPath {path1: String, path2: String},
-    SetSupersetSet {path: String,  set: HashSet<Vec<u8>>}
+    Snapshot { directory: String },
+    CreateNode { path: String, ty: NodeType },
+    DeleteNode { path: String },
+    ListKeys { path: String },
+    BlobPut { path: String, val: Vec<u8> },
+    BlobGet { path: String },
+    BlobSize { path: String },
+    QueuePush { path: String, val: Vec<u8> },
+    QueuePop { path: String },
+    QueueFront { path: String },
+    QueueBack { path: String },
+    QueueLen { path: String },
+    SetInsert { path: String, val: Vec<u8> },
+    SetRemove { path: String, val: Vec<u8> },
+    SetContains { path: String, val: Vec<u8> },
+    SetUnion {
+        paths: Vec<String>,
+        sets: Vec<HashSet<Vec<u8>>>
+    },
+    SetIntersection { path1: String, path2: String },
+    SetDifference { path1: String, path2: String },
+    SetSymmetricDifference { path1: String, path2: String },
+    SetSubsetPath { path1: String, path2: String },
+    SetSubsetSet { path: String, set: HashSet<Vec<u8>> },
+    SetSupersetPath { path1: String, path2: String },
+    SetSupersetSet { path: String, set: HashSet<Vec<u8>> }
 }
 
 impl TreeOp {
     pub fn is_write(&self) -> bool {
         match *self {
-            TreeOp::Snapshot {..} => true,
-            TreeOp::CreateNode {..} => true,
-            TreeOp::DeleteNode {..} => true,
-            TreeOp::BlobPut {..} => true,
-            TreeOp::QueuePush {..} => true,
-            TreeOp::QueuePop {..} => true,
-            TreeOp::SetInsert {..} => true,
-            TreeOp::SetRemove {..} => true,
-            _ => false
+            TreeOp::Snapshot { .. } => true,
+            TreeOp::CreateNode { .. } => true,
+            TreeOp::DeleteNode { .. } => true,
+            TreeOp::BlobPut { .. } => true,
+            TreeOp::QueuePush { .. } => true,
+            TreeOp::QueuePop { .. } => true,
+            TreeOp::SetInsert { .. } => true,
+            TreeOp::SetRemove { .. } => true,
+            _ => false,
         }
     }
 }
@@ -104,7 +107,11 @@ pub enum VrApiError {
     WrongType(String, NodeType),
     PathMustEndInDirectory(String),
     PathMustBeAbsolute(String),
-    CasFailed {path: String, expected: u64, actual: u64},
+    CasFailed {
+        path: String,
+        expected: u64,
+        actual: u64
+    },
     BadFormat(String),
     Io(String),
     EncodingError(String),

--- a/src/vr/vr_ctx_summary.rs
+++ b/src/vr/vr_ctx_summary.rs
@@ -5,10 +5,14 @@ use rabble::Pid;
 use super::replica::VersionedReplicas;
 use super::vr_ctx::VrCtx;
 
-/// This is all the state about a `VrCtx` that can be retrieved and sent over the wire to admin
-/// clients.. There is a lot of information maintained in a `VrCtx` that is expensive to transmit,
-/// such as the log. In a production system, shipping this for admin requests would be unnecessarily
-/// wasteful. All important details of a replica will instead be populated inside a VrCtxSummary
+/// This is all the state about a `VrCtx` that can be retrieved and sent over
+/// the wire to admin
+/// clients.. There is a lot of information maintained in a `VrCtx` that is
+/// expensive to transmit,
+/// such as the log. In a production system, shipping this for admin requests
+/// would be unnecessarily
+/// wasteful. All important details of a replica will instead be populated
+/// inside a VrCtxSummary
 /// instead.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VrCtxSummary {

--- a/src/vr/vr_envelope.rs
+++ b/src/vr/vr_envelope.rs
@@ -34,4 +34,3 @@ impl From<VrEnvelope> for Envelope<Msg> {
         }
     }
 }
-

--- a/src/vr/vr_fsm.rs
+++ b/src/vr/vr_fsm.rs
@@ -60,22 +60,28 @@ macro_rules! handle_common {
     }
 }
 
-/// A new epoch was just seen in the message. If it's a commit message with a `commit_num` equal to
-/// the `op`, it means that it's the reconfiguration being committed and this backup is up to
-/// date. If it's not an up to date config message then we don't know the new nodes. Let's try to
+/// A new epoch was just seen in the message. If it's a commit message with a
+/// `commit_num` equal to
+/// the `op`, it means that it's the reconfiguration being committed and this
+/// backup is up to
+/// date. If it's not an up to date config message then we don't know the new
+/// nodes. Let's try to
 /// learn those in learn_config before doing state transfer.
 ///
-/// Note that this function will never run on newly created replicas in the new group. New
-/// replicas are started knowing the old and new configuration and immediately start state transfer,
+/// Note that this function will never run on newly created replicas in the new
+/// group. New
+/// replicas are started knowing the old and new configuration and immediately
+/// start state transfer,
 /// thus skipping the need to run this function.
 ///
 /// Since this runs only on old nodes
 pub fn start_reconfiguration(ctx: &mut VrCtx, envelope: VrEnvelope, epoch: u64) -> Transition {
     ctx.epoch = epoch;
     match envelope.msg {
-        VrMsg::Commit {commit_num, ..} if commit_num == ctx.op => {
+        VrMsg::Commit { commit_num, .. } if commit_num == ctx.op => {
             ctx.last_received_time = SteadyTime::now();
-            // We only handle requests when we have the reconfiguration in the log. Backup commit
+            // We only handle requests when we have the reconfiguration in the log. Backup
+            // commit
             // will play it and we'll learn the new members.
             ctx.view = 0;
             let mut output = ctx.backup_commit(commit_num);
@@ -88,7 +94,7 @@ pub fn start_reconfiguration(ctx: &mut VrCtx, envelope: VrEnvelope, epoch: u64) 
                 return next!(primary, output);
             }
             next!(backup, output)
-        },
+        }
 
         // TODO: Fix this to do state transfer from the old group
         //
@@ -105,12 +111,16 @@ pub fn start_reconfiguration(ctx: &mut VrCtx, envelope: VrEnvelope, epoch: u64) 
 pub fn handle_later_view(ctx: &mut VrCtx, envelope: VrEnvelope, new_view: u64) -> Transition {
     debug!(ctx.logger,
            "handle_later_view: epoch = {}, new_view = {}, from = {}",
-           ctx.epoch, new_view, envelope.from);
+           ctx.epoch,
+           new_view,
+           envelope.from);
     match envelope.msg.clone() {
-        VrMsg::StartViewChange {from, ..} => {
+        VrMsg::StartViewChange { from, .. } => {
             debug!(ctx.logger,
                    "handle_later_view: StartViewChange: epoch = {}, new_view = {}, from = {}",
-                   ctx.epoch, new_view, from);
+                   ctx.epoch,
+                   new_view,
+                   from);
             let mut output = ctx.reset_view_change_state(new_view);
             output.extend(ctx.start_view_change());
             ctx.insert_view_change_message(from, envelope.msg);
@@ -119,17 +129,19 @@ pub fn handle_later_view(ctx: &mut VrCtx, envelope: VrEnvelope, new_view: u64) -
                 if computed_primary == ctx.pid {
                     let view = ctx.view;
                     output.extend(ctx.reset_view_change_state(view));
-                    return next!(wait_for_do_view_change, output)
+                    return next!(wait_for_do_view_change, output);
                 }
                 output.push(ctx.send_do_view_change(computed_primary));
                 return next!(wait_for_start_view, output);
             }
             next!(wait_for_start_view_change, output)
-        },
-        VrMsg::DoViewChange {from, ..} => {
+        }
+        VrMsg::DoViewChange { from, .. } => {
             debug!(ctx.logger,
                    "handle_later_view: DoViewChange : epoch = {}, new_view = {}, from = {}",
-                   ctx.epoch, new_view, from);
+                   ctx.epoch,
+                   new_view,
+                   from);
             let output = ctx.reset_view_change_state(new_view);
             ctx.insert_view_change_message(from, envelope.msg);
             if ctx.has_view_change_quorum() {
@@ -137,17 +149,27 @@ pub fn handle_later_view(ctx: &mut VrCtx, envelope: VrEnvelope, new_view: u64) -
                 return next!(primary, output);
             }
             next!(wait_for_do_view_change, output)
-        },
-        VrMsg::StartView{op, log, commit_num, ..} => {
-            debug!(ctx.logger, "Start View: DoViewChange : epoch = {}, new_view = {}, from = {}",
-                   ctx.epoch, new_view, envelope.from);
+        }
+        VrMsg::StartView {
+            op,
+            log,
+            commit_num,
+            ..
+        } => {
+            debug!(ctx.logger,
+                   "Start View: DoViewChange : epoch = {}, new_view = {}, from = {}",
+                   ctx.epoch,
+                   new_view,
+                   envelope.from);
             let output = ctx.become_backup(new_view, op, log, commit_num);
             next!(backup, output)
-        },
+        }
         _ => {
             debug!(ctx.logger,
                    "handle_later_view: Non-ViewChange msg: epoch = {}, new_view = {}, from = {}",
-                   ctx.epoch, new_view, envelope.from);
+                   ctx.epoch,
+                   new_view,
+                   envelope.from);
             // We've missed the view change and are likely out of date
             let output = ctx.start_state_transfer_new_view(new_view, envelope.correlation_id);
             next!(state_transfer, output)
@@ -155,10 +177,10 @@ pub fn handle_later_view(ctx: &mut VrCtx, envelope: VrEnvelope, new_view: u64) -
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// FSM STATES
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Startup states always receive a tick message to kick things off
+/// ////////////////////////////////////////////////////////////////////////////////////////////////
+/// FSM STATES
+/// ////////////////////////////////////////////////////////////////////////////////////////////////
+/// Startup states always receive a tick message to kick things off
 
 /// Start this FSM as part of a newly created namespace
 pub fn startup_new_namespace(ctx: &mut VrCtx, _: VrEnvelope) -> Transition {
@@ -172,7 +194,8 @@ pub fn startup_recovery(ctx: &mut VrCtx, _: VrEnvelope) -> Transition {
     next!(recovery, output)
 }
 
-/// This node was started as part of a reconfiguration. It's a new member to the group.
+/// This node was started as part of a reconfiguration. It's a new member to
+/// the group.
 pub fn startup_reconfiguration(ctx: &mut VrCtx, _: VrEnvelope) -> Transition {
     let output = ctx.start_state_transfer_reconfiguration();
     next!(reconfiguration_wait_for_new_state, output)
@@ -182,12 +205,12 @@ pub fn startup_reconfiguration(ctx: &mut VrCtx, _: VrEnvelope) -> Transition {
 pub fn primary(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     handle_common!(ctx, envelope, primary);
     match envelope.msg {
-        VrMsg::ClientRequest {..} => {
+        VrMsg::ClientRequest { .. } => {
             debug!(ctx.logger, "primary: got client request");
-            let output =  ctx.send_prepare(envelope);
+            let output = ctx.send_prepare(envelope);
             next!(primary, output)
-        },
-        VrMsg::PrepareOk {op, ref from, ..} if op > ctx.commit_num => {
+        }
+        VrMsg::PrepareOk { op, ref from, .. } if op > ctx.commit_num => {
             debug!(ctx.logger, "primary: got PrepareOk: op = {}", op);
             if ctx.has_commit_quorum(op, from.clone()) {
                 debug!(ctx.logger, "primary: has commit quorum: op = {}", op);
@@ -197,7 +220,7 @@ pub fn primary(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
                 return next!(primary, output);
             }
             next!(primary)
-        },
+        }
         VrMsg::Tick => {
             if ctx.prepare_requests.expired() {
                 debug!(ctx.logger, "primary: prepare expired");
@@ -209,27 +232,27 @@ pub fn primary(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
                 return next!(primary, output);
             }
             next!(primary)
-        },
-        VrMsg::GetState {op, from, ..} => {
+        }
+        VrMsg::GetState { op, from, .. } => {
             let output = ctx.send_new_state(op, from, envelope.correlation_id);
             next!(primary, vec![output])
-        },
-        VrMsg::Recovery {from, nonce} => {
+        }
+        VrMsg::Recovery { from, nonce } => {
             let output = ctx.send_recovery_response(from, nonce, envelope.correlation_id);
             next!(primary, vec![output])
-        },
-        VrMsg::Reconfiguration {..} => {
+        }
+        VrMsg::Reconfiguration { .. } => {
             if let Some(err_envelope) = ctx.validate_reconfig(&envelope) {
                 return next!(primary, vec![err_envelope]);
             }
             let output = ctx.send_prepare(envelope);
             next!(wait_for_reconfiguration_prepare_ok, output)
-        },
-        VrMsg::StartEpoch {..} => {
+        }
+        VrMsg::StartEpoch { .. } => {
             let output = ctx.send_epoch_started(envelope);
             next!(primary, output)
-        },
-        _ => next!(primary)
+        }
+        _ => next!(primary),
     }
 }
 
@@ -237,34 +260,39 @@ pub fn primary(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
 pub fn backup(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     handle_common!(ctx, envelope, backup);
     match envelope.msg {
-        VrMsg::Prepare {op, commit_num, ref msg, ..} if op == ctx.op + 1 => {
+        VrMsg::Prepare {
+            op,
+            commit_num,
+            ref msg,
+            ..
+        } if op == ctx.op + 1 => {
             ctx.last_received_time = SteadyTime::now();
-            let prepare_ok_envelope = ctx.send_prepare_ok((**msg).clone(),
-                                                          commit_num,
-                                                          envelope.correlation_id);
+            let prepare_ok_envelope =
+                ctx.send_prepare_ok((**msg).clone(), commit_num, envelope.correlation_id);
             next!(backup, prepare_ok_envelope)
-        },
-        VrMsg::Prepare {op, ..} if op > ctx.op + 1 => {
+        }
+        VrMsg::Prepare { op, .. } if op > ctx.op + 1 => {
             ctx.last_received_time = SteadyTime::now();
             let output = vec![ctx.send_get_state_to_random_replica(envelope.correlation_id)];
             next!(state_transfer, output)
-        },
-        VrMsg::Commit {commit_num, ..} if commit_num == ctx.commit_num => {
+        }
+        VrMsg::Commit { commit_num, .. } if commit_num == ctx.commit_num => {
             ctx.last_received_time = SteadyTime::now();
             next!(backup)
-        },
-        VrMsg::Commit {commit_num, ..} if commit_num == ctx.op => {
+        }
+        VrMsg::Commit { commit_num, .. } if commit_num == ctx.op => {
             ctx.last_received_time = SteadyTime::now();
             let output = ctx.backup_commit(commit_num);
             next!(backup, output)
-        },
-        VrMsg::Commit {commit_num, ..} if commit_num > ctx.op => {
+        }
+        VrMsg::Commit { commit_num, .. } if commit_num > ctx.op => {
             ctx.last_received_time = SteadyTime::now();
-            // Note that a primary cannot have a commit_num smaller than a backup by protocol
+            // Note that a primary cannot have a commit_num smaller than a backup by
+            // protocol
             // invariants
             let output = vec![ctx.send_get_state_to_random_replica(envelope.correlation_id)];
             next!(state_transfer, output)
-        },
+        }
         VrMsg::Tick => {
             if ctx.idle_timeout() {
                 let output = ctx.reset_and_start_view_change();
@@ -272,23 +300,23 @@ pub fn backup(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
             } else {
                 next!(backup)
             }
-        },
-        VrMsg::GetState{op, from, ..} => {
+        }
+        VrMsg::GetState { op, from, .. } => {
             let output = vec![ctx.send_new_state(op, from, envelope.correlation_id)];
             next!(backup, output)
-        },
-        VrMsg::Recovery {from, nonce} => {
+        }
+        VrMsg::Recovery { from, nonce } => {
             if *ctx.primary.as_ref().unwrap() == from {
                 let output = ctx.reset_and_start_view_change();
                 return next!(wait_for_start_view_change, output);
             }
             let output = ctx.send_recovery_response(from, nonce, envelope.correlation_id);
             next!(backup, vec![output])
-        },
-        VrMsg::StartEpoch {..} => {
+        }
+        VrMsg::StartEpoch { .. } => {
             let output = ctx.send_epoch_started(envelope);
             next!(backup, output)
-        },
+        }
         _ => {
             println!("Re-entering backup state: {}", ctx.pid.name);
             next!(backup)
@@ -296,15 +324,21 @@ pub fn backup(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     }
 }
 
-/// The first phase of a view change. This replica is waiting for a quorum of StartViewChange
+/// The first phase of a view change. This replica is waiting for a quorum of
+/// StartViewChange
 /// messages.
 pub fn wait_for_start_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
-    debug!(ctx.logger, "wait_for_start_view_change: epoch = {}, view = {}", ctx.epoch, ctx.view);
+    debug!(ctx.logger,
+           "wait_for_start_view_change: epoch = {}, view = {}",
+           ctx.epoch,
+           ctx.view);
     handle_common!(ctx, envelope, wait_for_start_view_change);
     match envelope.msg.clone() {
-        VrMsg::StartViewChange{from, ..} => {
-            debug!(ctx.logger, "received StartViewChange: epoch = {}, view = {}",
-                ctx.epoch, ctx.view);
+        VrMsg::StartViewChange { from, .. } => {
+            debug!(ctx.logger,
+                   "received StartViewChange: epoch = {}, view = {}",
+                   ctx.epoch,
+                   ctx.view);
             ctx.last_received_time = SteadyTime::now();
             ctx.insert_view_change_message(from, envelope.msg);
             if ctx.has_view_change_quorum() {
@@ -312,15 +346,16 @@ pub fn wait_for_start_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Tran
                 if computed_primary == ctx.pid {
                     let view = ctx.view;
                     let output = ctx.reset_view_change_state(view);
-                    return next!(wait_for_do_view_change, output)
+                    return next!(wait_for_do_view_change, output);
                 }
                 let output = ctx.send_do_view_change(computed_primary);
                 return next!(wait_for_start_view, vec![output]);
             }
             next!(wait_for_start_view_change)
-        },
-        VrMsg::DoViewChange {view, from, ..} => {
-            // Another replica got quorum of StartViewChange messages for this view and computed
+        }
+        VrMsg::DoViewChange { view, from, .. } => {
+            // Another replica got quorum of StartViewChange messages for this view and
+            // computed
             // that we are the primary for this view.
             let output = ctx.reset_view_change_state(view);
             ctx.insert_view_change_message(from, envelope.msg);
@@ -329,12 +364,18 @@ pub fn wait_for_start_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Tran
                 return next!(primary, output);
             }
             next!(wait_for_do_view_change, output)
-        },
-        VrMsg::StartView{view, op, log, commit_num, ..} => {
+        }
+        VrMsg::StartView {
+            view,
+            op,
+            log,
+            commit_num,
+            ..
+        } => {
             // Another replica was already elected primary for this view.
             let output = ctx.become_backup(view, op, log, commit_num);
             return next!(backup, output);
-        },
+        }
         VrMsg::Tick => {
             if ctx.view_change_expired() {
                 // We haven't changed views yet. Try again.
@@ -343,12 +384,15 @@ pub fn wait_for_start_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Tran
             } else {
                 next!(wait_for_start_view_change)
             }
-        },
-        VrMsg::Recovery {ref from, ..}  => {
-            // We don't handle recovery messages in view_change state. However, if we receive one
-            // from the primary for this view we know the election will never complete and trigger a
+        }
+        VrMsg::Recovery { ref from, .. } => {
+            // We don't handle recovery messages in view_change state. However, if we
+            // receive one
+            // from the primary for this view we know the election will never complete and
+            // trigger a
             // new view change immediately rather than waiting. It's possible this is an old
-            // recovery message lost in the network, but an extra view change is still safe.  It's
+            // recovery message lost in the network, but an extra view change is still
+            // safe.  It's
             // impossible that the recovery message is old when using TCP as transport.
             let primary = ctx.compute_primary();
             if primary == *from {
@@ -356,39 +400,43 @@ pub fn wait_for_start_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Tran
                 return next!(wait_for_start_view_change, output);
             }
             next!(wait_for_start_view_change)
-        },
-        VrMsg::Prepare {..} => {
-            // Another replica was already elected primary for this view.
-            let view = ctx.view;
-            let output = ctx.start_state_transfer_new_view(view, envelope.correlation_id);
-            next!(state_transfer, output)
-        },
-        VrMsg::Commit {..} => {
+        }
+        VrMsg::Prepare { .. } => {
             // Another replica was already elected primary for this view.
             let view = ctx.view;
             let output = ctx.start_state_transfer_new_view(view, envelope.correlation_id);
             next!(state_transfer, output)
         }
-        _ => next!(wait_for_start_view_change)
+        VrMsg::Commit { .. } => {
+            // Another replica was already elected primary for this view.
+            let view = ctx.view;
+            let output = ctx.start_state_transfer_new_view(view, envelope.correlation_id);
+            next!(state_transfer, output)
+        }
+        _ => next!(wait_for_start_view_change),
     }
 }
 
-/// The second phase of a ViewChange for the proposed primary of the new view. At least one replica
-/// has received a quorum of `StartViewChange` messages for a given view.  It has sent a
-/// `DoViewChange` message to the proposed primary for that view. In this state the proposed primary
-/// is waiting for a quorum of `DoViewChange` messages so that it can become the primary for that
+/// The second phase of a ViewChange for the proposed primary of the new view.
+/// At least one replica
+/// has received a quorum of `StartViewChange` messages for a given view.  It
+/// has sent a
+/// `DoViewChange` message to the proposed primary for that view. In this state
+/// the proposed primary
+/// is waiting for a quorum of `DoViewChange` messages so that it can become
+/// the primary for that
 /// view.
 pub fn wait_for_do_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     handle_common!(ctx, envelope, wait_for_do_view_change);
     match envelope.msg.clone() {
-        VrMsg::DoViewChange{from, ..} => {
+        VrMsg::DoViewChange { from, .. } => {
             ctx.insert_view_change_message(from, envelope.msg);
             if ctx.has_view_change_quorum() {
                 let output = ctx.become_primary();
                 return next!(primary, output);
             }
             next!(wait_for_do_view_change)
-        },
+        }
         VrMsg::Tick => {
             if ctx.view_change_expired() {
                 // We haven't changed views yet. Try again.
@@ -397,24 +445,34 @@ pub fn wait_for_do_view_change(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transit
             } else {
                 next!(wait_for_start_view_change)
             }
-        },
-        _ => next!(wait_for_do_view_change)
+        }
+        _ => next!(wait_for_do_view_change),
     }
 }
 
-/// The second phase of a ViewChange for a proposed backup in the new view. In this state, this
-/// replica has sent a `DoViewChange` message to the proposed primary for the new view. When the
-/// proposed primary has gotten a quorum of `DoViewChange` messages it will broadcast a `StartView`
-/// message to all new backups. This replica is waiting for that `StartView` message.
+/// The second phase of a ViewChange for a proposed backup in the new view. In
+/// this state, this
+/// replica has sent a `DoViewChange` message to the proposed primary for the
+/// new view. When the
+/// proposed primary has gotten a quorum of `DoViewChange` messages it will
+/// broadcast a `StartView`
+/// message to all new backups. This replica is waiting for that `StartView`
+/// message.
 pub fn wait_for_start_view(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     debug!(ctx.logger, "wait_for_start_view: epoch = {}, view = {}", ctx.epoch, ctx.view);
     handle_common!(ctx, envelope, wait_for_start_view);
     let view = ctx.view;
     match envelope.msg.clone() {
-        VrMsg::StartView {view, op, log, commit_num, ..} => {
+        VrMsg::StartView {
+            view,
+            op,
+            log,
+            commit_num,
+            ..
+        } => {
             let output = ctx.become_backup(view, op, log, commit_num);
             return next!(backup, output);
-        },
+        }
         VrMsg::Tick => {
             if ctx.view_change_expired() {
                 // We haven't changed views yet. Try again.
@@ -423,18 +481,18 @@ pub fn wait_for_start_view(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition 
             } else {
                 next!(wait_for_start_view_change)
             }
-        },
-        VrMsg::Prepare {..} => {
-            // We missed the StartView message
-            let output = ctx.start_state_transfer_new_view(view, envelope.correlation_id);
-            next!(state_transfer, output)
-        },
-        VrMsg::Commit {..} => {
+        }
+        VrMsg::Prepare { .. } => {
             // We missed the StartView message
             let output = ctx.start_state_transfer_new_view(view, envelope.correlation_id);
             next!(state_transfer, output)
         }
-        _ => next!(wait_for_start_view)
+        VrMsg::Commit { .. } => {
+            // We missed the StartView message
+            let output = ctx.start_state_transfer_new_view(view, envelope.correlation_id);
+            next!(state_transfer, output)
+        }
+        _ => next!(wait_for_start_view),
     }
 }
 
@@ -443,10 +501,10 @@ pub fn wait_for_start_view(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition 
 pub fn state_transfer(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     handle_common!(ctx, envelope, state_transfer);
     match envelope.msg {
-        VrMsg::NewState {..} => {
+        VrMsg::NewState { .. } => {
             let output = ctx.set_from_new_state_msg(envelope.msg);
             next!(backup, output)
-        },
+        }
         VrMsg::Tick => {
             // If we haven't gotten a NewState in time then re-broadcast GetState
             if ctx.idle_timeout() {
@@ -454,27 +512,28 @@ pub fn state_transfer(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
                 return next!(state_transfer, output);
             }
             next!(state_transfer)
-        },
-        _ => next!(state_transfer)
+        }
+        _ => next!(state_transfer),
     }
 }
 
-/// This is the state of the primary after it has sent a Prepare message containing the client
+/// This is the state of the primary after it has sent a Prepare message
+/// containing the client
 /// reconfiguration request.
 pub fn wait_for_reconfiguration_prepare_ok(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     handle_common!(ctx, envelope, wait_for_reconfiguration_prepare_ok);
     match envelope.msg {
-        VrMsg::PrepareOk {op, ref from, ..} if op == ctx.op => {
+        VrMsg::PrepareOk { op, ref from, .. } if op == ctx.op => {
             if ctx.has_commit_quorum(op, from.clone()) {
                 let output = ctx.primary_commit(op);
                 // We committed the reconfiguration request
                 if ctx.is_primary() {
                     return next!(primary, output);
                 }
-                return next!(backup, output)
+                return next!(backup, output);
             }
             next!(wait_for_reconfiguration_prepare_ok)
-        },
+        }
         VrMsg::Tick => {
             // If we haven't received quorum of PrepareOk in time then re-broadcast Prepare
             if ctx.prepare_requests.expired() {
@@ -483,25 +542,25 @@ pub fn wait_for_reconfiguration_prepare_ok(ctx: &mut VrCtx, envelope: VrEnvelope
             }
             next!(wait_for_reconfiguration_prepare_ok)
         }
-        _ => next!(wait_for_reconfiguration_prepare_ok)
+        _ => next!(wait_for_reconfiguration_prepare_ok),
     }
 }
 
 pub fn reconfiguration_wait_for_new_state(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     handle_common!(ctx, envelope, reconfiguration_wait_for_new_state);
     match envelope.msg {
-        VrMsg::NewState {op, ..} if op >= ctx.new_config.op => {
+        VrMsg::NewState { op, .. } if op >= ctx.new_config.op => {
             let mut output = ctx.set_from_new_state_msg(envelope.msg);
             if ctx.is_leaving() {
                 ctx.clear_epoch_started_msgs();
-                return next!(leaving, output)
+                return next!(leaving, output);
             }
             output.extend_from_slice(&ctx.broadcast_epoch_started(envelope.correlation_id));
             if ctx.is_primary() {
-                return next!(primary, output)
+                return next!(primary, output);
             }
             next!(backup, output)
-        },
+        }
         VrMsg::Tick => {
             // If we haven't gotten a NewState in time then re-broadcast GetState
             if ctx.idle_timeout() {
@@ -509,19 +568,21 @@ pub fn reconfiguration_wait_for_new_state(ctx: &mut VrCtx, envelope: VrEnvelope)
                 return next!(reconfiguration_wait_for_new_state, output);
             }
             next!(reconfiguration_wait_for_new_state)
-        },
-        _ => next!(reconfiguration_wait_for_new_state)
+        }
+        _ => next!(reconfiguration_wait_for_new_state),
     }
 }
 
 
-/// A replica has just started back up and needs to recover its log from other replicas
+/// A replica has just started back up and needs to recover its log from other
+/// replicas
 pub fn recovery(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     match envelope.msg {
-        VrMsg::RecoveryResponse {..} => {
+        VrMsg::RecoveryResponse { .. } => {
             ctx.update_recovery_state(envelope.msg);
-            ctx.commit_recovery().map_or(next!(recovery), |output| next!(backup, output))
-        },
+            ctx.commit_recovery()
+               .map_or(next!(recovery), |output| next!(backup, output))
+        }
         VrMsg::Tick => {
             if ctx.recovery_expired() {
                 let output = ctx.start_recovery();
@@ -529,27 +590,30 @@ pub fn recovery(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
             } else {
                 next!(recovery)
             }
-        },
-        _ => next!(recovery)
+        }
+        _ => next!(recovery),
     }
 }
 
 
-/// A replica is in this state after it has a reconfiguration request in its log and it is not in
-/// the new configuration. It is waiting for f' + 1 EpochStarted messages so that it can shutdown.
+/// A replica is in this state after it has a reconfiguration request in its
+/// log and it is not in
+/// the new configuration. It is waiting for f' + 1 EpochStarted messages so
+/// that it can shutdown.
 pub fn leaving(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
     match envelope.msg {
         // TODO: What if epoch > ctx.epoch ?
-        VrMsg::EpochStarted {epoch, ref from, ..} if epoch == ctx.epoch => {
-            ctx.epoch_started_msgs.insert(from.clone(), envelope.msg.clone());
+        VrMsg::EpochStarted { epoch, ref from, .. } if epoch == ctx.epoch => {
+            ctx.epoch_started_msgs
+               .insert(from.clone(), envelope.msg.clone());
             if ctx.epoch_started_msgs.has_quorum() {
                 ctx.clear_epoch_started_msgs();
                 let output = vec![FsmOutput::Announcement(NamespaceMsg::Stop(ctx.pid.clone()),
                                                           ctx.pid.clone())];
-                return next!(shutdown, output)
+                return next!(shutdown, output);
             }
             next!(leaving)
-        },
+        }
         VrMsg::Tick => {
             if ctx.epoch_started_msgs.is_expired() {
                 let output = ctx.broadcast_start_epoch();
@@ -557,20 +621,21 @@ pub fn leaving(ctx: &mut VrCtx, envelope: VrEnvelope) -> Transition {
             }
             next!(leaving)
         }
-        _ => next!(leaving)
+        _ => next!(leaving),
     }
 }
 
-/// This replica has already told the dispatcher to shut it down. It just waits in this state and
+/// This replica has already told the dispatcher to shut it down. It just waits
+/// in this state and
 /// doesn't respond to any messages from this point out.
 pub fn shutdown(_ctx: &mut VrCtx, _: VrEnvelope) -> Transition {
     next!(shutdown)
 }
 
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// END OF FSM STATES
-///////////////////////////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////////////////////////
+/// END OF FSM STATES
+/// ////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 fn learn_config(_ctx: &mut VrCtx, _epoch: u64) -> Transition {

--- a/src/vr/vrmsg.rs
+++ b/src/vr/vrmsg.rs
@@ -79,12 +79,9 @@ pub enum VrMsg {
         op: u64,
         primary: Option<Pid>,
         commit_num: u64,
-        log_tail: Vec<VrMsg>,
+        log_tail: Vec<VrMsg>
     },
-    Recovery {
-        from: Pid,
-        nonce: Uuid
-    },
+    Recovery { from: Pid, nonce: Uuid },
     RecoveryResponse {
         epoch: u64,
         view: u64,
@@ -101,46 +98,44 @@ pub enum VrMsg {
         old_config: VersionedReplicas,
         new_config: VersionedReplicas
     },
-    EpochStarted {
-        epoch: u64,
-        from: Pid
-    }
+    EpochStarted { epoch: u64, from: Pid }
 }
 
 impl VrMsg {
-    // This is only used for filtering messages in vr_fsm. However we don't ever want to filter
+    // This is only used for filtering messages in vr_fsm. However we don't ever
+    // want to filter
     // client requests from the primary, so we exclude `VrMsg::Reconfiguration`
     pub fn get_epoch(&self) -> Option<u64> {
         match *self {
-            VrMsg::ClientReply {epoch, ..} => Some(epoch),
-            VrMsg::StartViewChange {epoch, ..} => Some(epoch),
-            VrMsg::DoViewChange {epoch, ..} => Some(epoch),
-            VrMsg::StartView {epoch, ..} => Some(epoch),
-            VrMsg::Prepare {epoch, ..} => Some(epoch),
-            VrMsg::PrepareOk {epoch, ..} => Some(epoch),
-            VrMsg::Commit {epoch, ..} => Some(epoch),
-            VrMsg::GetState {epoch, ..} => Some(epoch),
-            VrMsg::NewState {epoch, ..} => Some(epoch),
-            VrMsg::RecoveryResponse {epoch, ..} => Some(epoch),
-            VrMsg::StartEpoch {epoch, ..} => Some(epoch),
-            VrMsg::EpochStarted {epoch, ..} => Some(epoch),
-            _ => None
+            VrMsg::ClientReply { epoch, .. } => Some(epoch),
+            VrMsg::StartViewChange { epoch, .. } => Some(epoch),
+            VrMsg::DoViewChange { epoch, .. } => Some(epoch),
+            VrMsg::StartView { epoch, .. } => Some(epoch),
+            VrMsg::Prepare { epoch, .. } => Some(epoch),
+            VrMsg::PrepareOk { epoch, .. } => Some(epoch),
+            VrMsg::Commit { epoch, .. } => Some(epoch),
+            VrMsg::GetState { epoch, .. } => Some(epoch),
+            VrMsg::NewState { epoch, .. } => Some(epoch),
+            VrMsg::RecoveryResponse { epoch, .. } => Some(epoch),
+            VrMsg::StartEpoch { epoch, .. } => Some(epoch),
+            VrMsg::EpochStarted { epoch, .. } => Some(epoch),
+            _ => None,
         }
     }
 
     pub fn get_view(&self) -> Option<u64> {
         match *self {
-            VrMsg::ClientReply {view, ..} => Some(view),
-            VrMsg::StartViewChange {view, ..} => Some(view),
-            VrMsg::DoViewChange {view, ..} => Some(view),
-            VrMsg::StartView {view, ..} => Some(view),
-            VrMsg::Prepare {view, ..} => Some(view),
-            VrMsg::PrepareOk {view, ..} => Some(view),
-            VrMsg::Commit {view, ..} => Some(view),
-            VrMsg::GetState {view, ..} => Some(view),
-            VrMsg::NewState {view, ..} => Some(view),
-            VrMsg::RecoveryResponse {view, ..} => Some(view),
-            _ => None
+            VrMsg::ClientReply { view, .. } => Some(view),
+            VrMsg::StartViewChange { view, .. } => Some(view),
+            VrMsg::DoViewChange { view, .. } => Some(view),
+            VrMsg::StartView { view, .. } => Some(view),
+            VrMsg::Prepare { view, .. } => Some(view),
+            VrMsg::PrepareOk { view, .. } => Some(view),
+            VrMsg::Commit { view, .. } => Some(view),
+            VrMsg::GetState { view, .. } => Some(view),
+            VrMsg::NewState { view, .. } => Some(view),
+            VrMsg::RecoveryResponse { view, .. } => Some(view),
+            _ => None,
         }
     }
 }

--- a/tests/static_membership_unit.rs
+++ b/tests/static_membership_unit.rs
@@ -1,12 +1,18 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The tests in this module test VR operation by running a bunch of VR replicas in a single tenant on
-//! one node. By seperating transport from Fsm operation we are able to run a VR group locally or
-//! remotely. While in production, we never want to run more than one replica on a given node, for
-//! testing running them locally allows us complete control over how they interact and how we send
-//! messages. We can fully stop the peers and inspect the global state to ensure that the protocol
-//! invariants are maintained. This is in addition to the FSM level constraints that operate on a
+//! The tests in this module test VR operation by running a bunch of VR
+//! replicas in a single tenant on
+//! one node. By seperating transport from Fsm operation we are able to run a
+//! VR group locally or
+//! remotely. While in production, we never want to run more than one replica
+//! on a given node, for
+//! testing running them locally allows us complete control over how they
+//! interact and how we send
+//! messages. We can fully stop the peers and inspect the global state to
+//! ensure that the protocol
+//! invariants are maintained. This is in addition to the FSM level constraints
+//! that operate on a
 //! single FSM.
 
 extern crate uuid;
@@ -47,25 +53,32 @@ fn basic_ops() -> Result<(), String> {
     scheduler.elect_initial_leader();
     let replicas = scheduler.new_config.replicas.clone();
 
-    let op = VrApiReq::TreeOp(TreeOp::CreateNode {path: "/test_root".to_string(),
-                                                  ty: NodeType::Blob});
-    let msg = VrMsg::ClientRequest {client_id: "test_client".to_string(), op: op, request_num: 1};
+    let op = VrApiReq::TreeOp(TreeOp::CreateNode {
+                                  path: "/test_root".to_string(),
+                                  ty: NodeType::Blob
+                              });
+    let msg = VrMsg::ClientRequest {
+        client_id: "test_client".to_string(),
+        op: op,
+        request_num: 1
+    };
     let primary = &replicas[1];
 
     // See if we get a response to our first operation.
-    try!(scheduler.send_msg(primary, msg.clone()));
-    let replies = try!(scheduler.send_until_empty());
+    scheduler.send_msg(primary, msg.clone())?;
+    let replies = scheduler.send_until_empty()?;
 
     assert_create_response(replies);
 
     // Resend the message. We should get the same response
-    /* TODO: Re-enable this check when we add back in client table support
-    scheduler.send_msg(primary, msg.clone());
-    let replies = scheduler.send_until_empty();
-    assert_create_response(replies);
-    */
+    // TODO: Re-enable this check when we add back in client table support
+    // scheduler.send_msg(primary, msg.clone());
+    // let replies = scheduler.send_until_empty();
+    // assert_create_response(replies);
+    //
 
-    // The log should still only have one operation in it, since the response was returned from the
+    // The log should still only have one operation in it, since the response was
+    // returned from the
     // client_table
     {
         let (_, primary_ctx) = scheduler.get_state(primary).unwrap();
@@ -73,29 +86,39 @@ fn basic_ops() -> Result<(), String> {
         assert_eq!(primary_ctx.op, 1);
     }
 
-    try!(assert_put_and_get(primary, &mut scheduler));
+    assert_put_and_get(primary, &mut scheduler)?;
 
-    // A tick timeout occurs resulting in a commit message being sent. Note that the current
-    // timeouts are all 0, therefore no sleeps are necessary and this is deterministic.
-    try!(assert_commit_gets_sent(primary, &mut scheduler, 3));
+    // A tick timeout occurs resulting in a commit message being sent. Note that
+    // the current
+    // timeouts are all 0, therefore no sleeps are necessary and this is
+    // deterministic.
+    assert_commit_gets_sent(primary, &mut scheduler, 3)?;
 
     // Force a tick timeout at a backup and result in a view change
     assert_second_view_change(&replicas, &mut scheduler)
 }
 
-/// We guarantee a state transfer by dropping all messages to r1 and proceeding with the basic ops
+/// We guarantee a state transfer by dropping all messages to r1 and proceeding
+/// with the basic ops
 /// test. Then we "turn r1 back on" and watch the state change occur.
 fn state_transfer() -> Result<(), String> {
     let mut scheduler = Scheduler::new(3);
     scheduler.elect_initial_leader();
     let replicas = scheduler.new_config.replicas.clone();
 
-    let op = VrApiReq::TreeOp(TreeOp::CreateNode {path: "/test_root".to_string(), ty: NodeType::Blob});
-    let msg = VrMsg::ClientRequest {client_id: "test_client".to_string(), op: op, request_num: 1};
+    let op = VrApiReq::TreeOp(TreeOp::CreateNode {
+                                  path: "/test_root".to_string(),
+                                  ty: NodeType::Blob
+                              });
+    let msg = VrMsg::ClientRequest {
+        client_id: "test_client".to_string(),
+        op: op,
+        request_num: 1
+    };
     let primary = &replicas[1];
-    try!(scheduler.send_msg(primary, msg.clone()));
+    scheduler.send_msg(primary, msg.clone())?;
     // dispatch all commands, dropping messages to r1
-    let replies = try!(scheduler.send_until_empty_with_drop(&replicas[0]));
+    let replies = scheduler.send_until_empty_with_drop(&replicas[0])?;
 
     // Ensure we still commit the create op
     assert_create_response(replies);
@@ -109,7 +132,7 @@ fn state_transfer() -> Result<(), String> {
     }
 
     // Send a commit to all nodes and ensure the state transfer
-    try!(assert_commit_gets_sent(primary, &mut scheduler, 1));
+    assert_commit_gets_sent(primary, &mut scheduler, 1)?;
 
     // Ensure r1 has received and committed the op
     let (_, r1_ctx) = scheduler.get_state(&replicas[0]).unwrap();
@@ -125,23 +148,30 @@ fn recovery() -> Result<(), String> {
     scheduler.elect_initial_leader();
     let replicas = scheduler.new_config.replicas.clone();
 
-    let op = VrApiReq::TreeOp(TreeOp::CreateNode {path: "/test_root".to_string(), ty: NodeType::Blob});
-    let msg = VrMsg::ClientRequest {client_id: "test_client".to_string(), op: op, request_num: 1};
+    let op = VrApiReq::TreeOp(TreeOp::CreateNode {
+                                  path: "/test_root".to_string(),
+                                  ty: NodeType::Blob
+                              });
+    let msg = VrMsg::ClientRequest {
+        client_id: "test_client".to_string(),
+        op: op,
+        request_num: 1
+    };
     let view1_primary = &replicas[1];
 
     // See if we get a response to our first operation.
-    try!(scheduler.send_msg(view1_primary, msg.clone()));
-    let replies = try!(scheduler.send_until_empty());
+    scheduler.send_msg(view1_primary, msg.clone())?;
+    let replies = scheduler.send_until_empty()?;
     assert_create_response(replies);
-    try!(assert_commit_gets_sent(view1_primary, &mut scheduler, 1));
+    assert_commit_gets_sent(view1_primary, &mut scheduler, 1)?;
 
     // Stop the view1_primary and trigger an election
     scheduler.stop(view1_primary);
-    try!(scheduler.send_msg(&replicas[0], VrMsg::Tick));
-    try!(scheduler.send_until_empty());
+    scheduler.send_msg(&replicas[0], VrMsg::Tick)?;
+    scheduler.send_until_empty()?;
 
     // Restart the view1_primary and check the status of the replicas
-    try!(scheduler.restart(view1_primary));
+    scheduler.restart(view1_primary)?;
 
     {
         let (state, ctx) = scheduler.get_state(view1_primary).unwrap();
@@ -161,8 +191,8 @@ fn recovery() -> Result<(), String> {
     }
 
     // Send a tick to the old view1_primary so that it starts recovery
-    try!(scheduler.send_msg(view1_primary, VrMsg::Tick));
-    try!(scheduler.send_until_empty());
+    scheduler.send_msg(view1_primary, VrMsg::Tick)?;
+    scheduler.send_until_empty()?;
 
     // Ensure that the old view1_primary is now a backup with the proper state
     let (state, ctx) = scheduler.get_state(view1_primary).unwrap();
@@ -180,23 +210,27 @@ fn reconfiguration() -> Result<(), String> {
 
     assert_eq!(scheduler.fsms.len(), 3);
 
-    let new_replica = Pid {group: replicas[0].group.clone(),
-                           name: "r4".to_string(),
-                           node: replicas[0].node.clone() };
+    let new_replica = Pid {
+        group: replicas[0].group.clone(),
+        name: "r4".to_string(),
+        node: replicas[0].node.clone()
+    };
     replicas.push(new_replica);
-    let msg = VrMsg::Reconfiguration{client_req_num: 1,
-                                     epoch: 1,
-                                     replicas: replicas.clone()};
+    let msg = VrMsg::Reconfiguration {
+        client_req_num: 1,
+        epoch: 1,
+        replicas: replicas.clone()
+    };
     let primary = &replicas[1];
     // Send reconfiguration to the primary and commit it
-    try!(scheduler.send_msg(primary, msg.clone()));
-    let mut replies = try!(scheduler.send_until_empty());
+    scheduler.send_msg(primary, msg.clone())?;
+    let mut replies = scheduler.send_until_empty()?;
 
     assert_eq!(replies.len(), 1);
 
     // Assure that we get a response to the committed reconfiguration
-    let VrEnvelope{msg, ..} = replies.pop().unwrap();
-    if let VrMsg::ClientReply {request_num, value, ..} = msg {
+    let VrEnvelope { msg, .. } = replies.pop().unwrap();
+    if let VrMsg::ClientReply { request_num, value, .. } = msg {
         assert_eq!(request_num, 1);
         assert_eq!(value, VrApiRsp::Ok);
     } else {
@@ -207,17 +241,18 @@ fn reconfiguration() -> Result<(), String> {
     assert_eq!(scheduler.fsms.len(), 4);
 
     // Send a Tick to start reconfiguration state transfer
-    try!(scheduler.send_msg(&replicas[3], VrMsg::Tick));
-    try!(scheduler.send_until_empty());
+    scheduler.send_msg(&replicas[3], VrMsg::Tick)?;
+    scheduler.send_until_empty()?;
     let (state, _) = scheduler.get_state(&replicas[3]).unwrap();
     assert_eq!(state, "backup");
 
     assert_new_epoch(&replicas, &mut scheduler);
 
-    // Send a tick to the new replica and dispatch all resulting messages so that it can cause a
+    // Send a tick to the new replica and dispatch all resulting messages so that
+    // it can cause a
     // view change in the new epoch.
-    try!(scheduler.send_msg(&replicas[3], VrMsg::Tick));
-    try!(scheduler.send_until_empty());
+    scheduler.send_msg(&replicas[3], VrMsg::Tick)?;
+    scheduler.send_until_empty()?;
     let (state, ctx) = scheduler.get_state(&replicas[3]).unwrap();
     assert_eq!(ctx.epoch, 2);
     assert_eq!(state, "backup");
@@ -251,8 +286,8 @@ fn assert_new_epoch(replicas: &Vec<Pid>, scheduler: &mut Scheduler) {
 }
 
 fn assert_second_view_change(replicas: &Vec<Pid>, scheduler: &mut Scheduler) -> Result<(), String> {
-    try!(scheduler.send_msg(&replicas[0], VrMsg::Tick));
-    try!(scheduler.send_until_empty());
+    scheduler.send_msg(&replicas[0], VrMsg::Tick)?;
+    scheduler.send_until_empty()?;
     if let Some((state, ctx)) = scheduler.get_state(&replicas[0]) {
         assert_eq!(state, "backup");
         assert_eq!(ctx.view, 2);
@@ -280,16 +315,17 @@ fn assert_second_view_change(replicas: &Vec<Pid>, scheduler: &mut Scheduler) -> 
 // Ensure the primary sends a commit to the 2 backups
 fn assert_commit_gets_sent(primary: &Pid,
                            scheduler: &mut Scheduler,
-                           expected_commit: u64) -> Result<(), String>
-{
-    try!(scheduler.send_msg(primary, VrMsg::Tick));
+                           expected_commit: u64)
+                           -> Result<(), String> {
+    scheduler.send_msg(primary, VrMsg::Tick)?;
     for _ in 0..2 {
-        if let Some(FsmOutput::Vr(VrEnvelope {to, msg, ..})) = scheduler.next() {
+        if let Some(FsmOutput::Vr(VrEnvelope { to, msg, .. })) =
+            scheduler.next() {
             let msg2 = msg.clone();
-            if let VrMsg::Commit {view, commit_num, ..} = msg {
+            if let VrMsg::Commit { view, commit_num, .. } = msg {
                 assert_eq!(view, 1);
                 assert_eq!(commit_num, expected_commit);
-                try!(scheduler.send_msg(&to, msg2));
+                scheduler.send_msg(&to, msg2)?;
             } else {
                 println!("failing msg = {:#?}", msg);
                 assert!(false);
@@ -298,25 +334,41 @@ fn assert_commit_gets_sent(primary: &Pid,
             assert!(false);
         }
     }
-    try!(scheduler.send_until_empty());
+    scheduler.send_until_empty()?;
     Ok(())
 }
 
 fn assert_put_and_get(primary: &Pid, scheduler: &mut Scheduler) -> Result<(), String> {
-    let put_op = VrApiReq::TreeOp(TreeOp::BlobPut { path: "/test_root".to_string(), val: b"hello".to_vec()});
-    let put_msg = VrMsg::ClientRequest {client_id: "test_client".to_string(), op: put_op, request_num: 2};
-    try!(scheduler.send_msg(primary, put_msg));
-    try!(scheduler.send_until_empty());
-    let get_op = VrApiReq::TreeOp(TreeOp::BlobGet { path: "/test_root".to_string()});
-    let get_msg = VrMsg::ClientRequest {client_id: "test_client".to_string(), op: get_op, request_num: 3};
-    try!(scheduler.send_msg(primary, get_msg));
-    let mut replies = try!(scheduler.send_until_empty());
+    let put_op = VrApiReq::TreeOp(TreeOp::BlobPut {
+                                      path: "/test_root".to_string(),
+                                      val: b"hello".to_vec()
+                                  });
+    let put_msg = VrMsg::ClientRequest {
+        client_id: "test_client".to_string(),
+        op: put_op,
+        request_num: 2
+    };
+    scheduler.send_msg(primary, put_msg)?;
+    scheduler.send_until_empty()?;
+    let get_op = VrApiReq::TreeOp(TreeOp::BlobGet { path: "/test_root".to_string() });
+    let get_msg = VrMsg::ClientRequest {
+        client_id: "test_client".to_string(),
+        op: get_op,
+        request_num: 3
+    };
+    scheduler.send_msg(primary, get_msg)?;
+    let mut replies = scheduler.send_until_empty()?;
 
     // Ensure we get back the value stored
     assert_eq!(replies.len(), 1);
 
-    let VrEnvelope{msg, ..} = replies.pop().unwrap();
-    if let VrMsg::ClientReply{epoch, view, request_num, value} = msg {
+    let VrEnvelope { msg, .. } = replies.pop().unwrap();
+    if let VrMsg::ClientReply {
+               epoch,
+               view,
+               request_num,
+               value
+           } = msg {
         assert_eq!(epoch, 1);
         assert_eq!(view, 1);
         assert_eq!(request_num, 3);
@@ -335,8 +387,8 @@ fn assert_put_and_get(primary: &Pid, scheduler: &mut Scheduler) -> Result<(), St
 
 fn assert_create_response(mut replies: Vec<VrEnvelope>) {
     assert_eq!(replies.len(), 1);
-    let VrEnvelope{msg, ..} = replies.pop().unwrap();
-    if let VrMsg::ClientReply{request_num, value, ..} = msg {
+    let VrEnvelope { msg, .. } = replies.pop().unwrap();
+    if let VrMsg::ClientReply { request_num, value, .. } = msg {
         assert_eq!(request_num, 1);
         assert_eq!(value, VrApiRsp::Ok);
     } else {

--- a/tests/utils/arbitrary.rs
+++ b/tests/utils/arbitrary.rs
@@ -17,11 +17,11 @@ impl Arbitrary for Path {
         let range = Range::new(1u8, 11u8);
         let depth = range.ind_sample(g);
         let labels = ['a', 'b', 'c', 'd', 'e'];
-        let mut path = String::with_capacity((depth*2 - 1) as usize);
+        let mut path = String::with_capacity((depth * 2 - 1) as usize);
         path = (0..depth).fold(path, |mut acc, _| {
-                acc.push('/');
-                acc.push(*g.choose(&labels).unwrap());
-                acc
+            acc.push('/');
+            acc.push(*g.choose(&labels).unwrap());
+            acc
         });
         Path(path)
     }
@@ -46,7 +46,7 @@ impl Arbitrary for Op {
             85...90 => Op::ViewChange,
             90...92 => Op::CrashPrimary,
             92...95 => Op::CrashBackup,
-            _ => Op::Restart
+            _ => Op::Restart,
         }
     }
 }
@@ -57,10 +57,10 @@ pub struct ClientRequest(pub VrMsg);
 impl Arbitrary for ClientRequest {
     fn arbitrary<G: Gen>(g: &mut G) -> ClientRequest {
         ClientRequest(VrMsg::ClientRequest {
-            client_id: "test-client".to_string(),
-            request_num: 0, // This will get mutated
-            op: ApiReq::arbitrary(g).0
-        })
+                          client_id: "test-client".to_string(),
+                          request_num: 0, // This will get mutated
+                          op: ApiReq::arbitrary(g).0
+                      })
     }
 }
 
@@ -72,9 +72,19 @@ impl Arbitrary for ApiReq {
         let range = Range::new(0, 3);
         let path = Path::arbitrary(g).0;
         let op = match range.ind_sample(&mut thread_rng()) {
-            0 => TreeOp::CreateNode {path: path, ty: NodeType::Blob},
-            1 => TreeOp::BlobPut {path: path, val: b"hello".to_vec()},
-            _ => TreeOp::BlobGet {path: path}
+            0 => {
+                TreeOp::CreateNode {
+                    path: path,
+                    ty: NodeType::Blob
+                }
+            }
+            1 => {
+                TreeOp::BlobPut {
+                    path: path,
+                    val: b"hello".to_vec()
+                }
+            }
+            _ => TreeOp::BlobGet { path: path },
         };
         ApiReq(VrApiReq::TreeOp(op))
     }

--- a/tests/utils/macros.rs
+++ b/tests/utils/macros.rs
@@ -1,7 +1,8 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// An assert that doesn't panic on failure, but instead returns a result<(), String> with an
+/// An assert that doesn't panic on failure, but instead returns a result<(),
+/// String> with an
 /// appropriate error message.
 #[macro_export]
 macro_rules! safe_assert {

--- a/tests/utils/op_invariants.rs
+++ b/tests/utils/op_invariants.rs
@@ -1,34 +1,32 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains test functions for specific API operations. It's intended to be general
+//! This module contains test functions for specific API operations. It's
+//! intended to be general
 //! enough to use for multiple tests.
 
 use super::scheduler::Scheduler;
-use haret::vr::{VrMsg, VrCtx, VrEnvelope, VrApiReq, VrApiRsp, VrApiError, TreeOp, TreeOpResult, NodeType};
+use haret::vr::{VrMsg, VrCtx, VrEnvelope, VrApiReq, VrApiRsp, VrApiError, TreeOp, TreeOpResult,
+                NodeType};
 use vertree::{self, Reply, Value};
 
 pub fn assert_create_response(scheduler: &Scheduler,
                               request: VrMsg,
-                              reply: VrEnvelope) -> Result<(), String>
-{
-    let (request_num, api_req, api_rsp) = try!(match_client_reply(request, reply));
-    let (path, ty) = if let VrApiReq::TreeOp(TreeOp::CreateNode {path, ty}) = api_req {
+                              reply: VrEnvelope)
+                              -> Result<(), String> {
+    let (request_num, api_req, api_rsp) = match_client_reply(request, reply)?;
+    let (path, ty) = if let VrApiReq::TreeOp(TreeOp::CreateNode { path, ty }) = api_req {
         (path, ty)
     } else {
         fail!()
     };
 
     match api_rsp {
-        VrApiRsp::Ok => {
-            assert_successful_create(scheduler, path, request_num, ty)
-        },
+        VrApiRsp::Ok => assert_successful_create(scheduler, path, request_num, ty),
         VrApiRsp::Error(VrApiError::AlreadyExists(_)) => {
             assert_successful_create(scheduler, path, request_num, ty)
-        },
-        VrApiRsp::Error(VrApiError::PathMustEndInDirectory(_)) => {
-            Ok(())
-        },
+        }
+        VrApiRsp::Error(VrApiError::PathMustEndInDirectory(_)) => Ok(()),
         e => {
             println!("e = {:?}", e);
             fail!()
@@ -40,26 +38,25 @@ pub fn assert_create_response(scheduler: &Scheduler,
 /// Assertions for puts that aren't CAS
 pub fn assert_put_response(scheduler: &Scheduler,
                            request: VrMsg,
-                           reply: VrEnvelope) -> Result<(), String>
-{
-    let (request_num, api_req, api_rsp) = try!(match_client_reply(request, reply));
-    let (path, data) =
-        if let VrApiReq::TreeOp(TreeOp::BlobPut {path, val, ..}) = api_req {
-            (path, val)
-        } else {
-            fail!()
-        };
+                           reply: VrEnvelope)
+                           -> Result<(), String> {
+    let (request_num, api_req, api_rsp) = match_client_reply(request, reply)?;
+    let (path, data) = if let VrApiReq::TreeOp(TreeOp::BlobPut { path, val, .. }) = api_req {
+        (path, val)
+    } else {
+        fail!()
+    };
 
     match api_rsp {
         VrApiRsp::TreeOpResult(TreeOpResult::Ok(_)) => {
             assert_successful_put_or_get(scheduler, path, request_num, data)
-        },
+        }
         VrApiRsp::Error(VrApiError::AlreadyExists(_)) => Ok(()),
         VrApiRsp::Error(VrApiError::PathMustEndInDirectory(_)) => Ok(()),
         VrApiRsp::Error(VrApiError::WrongType(_, ty)) => safe_assert_eq!(ty, NodeType::Directory),
         VrApiRsp::Error(VrApiError::DoesNotExist(_)) => {
             assert_element_not_found_primary(scheduler, path)
-        },
+        }
         e => {
             println!("put unhandled error = {:?}", e);
             fail!()
@@ -69,10 +66,10 @@ pub fn assert_put_response(scheduler: &Scheduler,
 
 pub fn assert_get_response(scheduler: &Scheduler,
                            request: VrMsg,
-                           reply: VrEnvelope) -> Result<(), String>
-{
-    let (request_num, api_req, api_rsp) = try!(match_client_reply(request, reply));
-    let path = if let VrApiReq::TreeOp(TreeOp::BlobGet {path, ..}) = api_req {
+                           reply: VrEnvelope)
+                           -> Result<(), String> {
+    let (request_num, api_req, api_rsp) = match_client_reply(request, reply)?;
+    let path = if let VrApiReq::TreeOp(TreeOp::BlobGet { path, .. }) = api_req {
         path
     } else {
         fail!()
@@ -81,13 +78,13 @@ pub fn assert_get_response(scheduler: &Scheduler,
     match api_rsp {
         VrApiRsp::TreeOpResult(TreeOpResult::Blob(data, _)) => {
             assert_successful_put_or_get(scheduler, path, request_num, data)
-        },
+        }
         VrApiRsp::Error(VrApiError::AlreadyExists(_)) => Ok(()),
         VrApiRsp::Error(VrApiError::PathMustEndInDirectory(_)) => Ok(()),
         VrApiRsp::Error(VrApiError::WrongType(_, ty)) => safe_assert_eq!(ty, NodeType::Directory),
         VrApiRsp::Error(VrApiError::DoesNotExist(_)) => {
             assert_element_not_found_primary(scheduler, path)
-        },
+        }
         e => {
             println!("get unhandled error = {:?}", e);
             fail!()
@@ -95,14 +92,19 @@ pub fn assert_get_response(scheduler: &Scheduler,
     }
 }
 
-/// Attempt to retrieve a client reply and extract useful data from it, along with data from the
+/// Attempt to retrieve a client reply and extract useful data from it, along
+/// with data from the
 /// request.
-fn match_client_reply(request: VrMsg, reply: VrEnvelope)
-  -> Result<(u64, VrApiReq, VrApiRsp), String>
-{
-    if let VrMsg::ClientRequest {op, request_num, ..} = request {
-        let VrEnvelope {msg, ..} = reply;
-        if let VrMsg::ClientReply {request_num: reply_req_num, value, ..} = msg {
+fn match_client_reply(request: VrMsg,
+                      reply: VrEnvelope)
+                      -> Result<(u64, VrApiReq, VrApiRsp), String> {
+    if let VrMsg::ClientRequest { op, request_num, .. } = request {
+        let VrEnvelope { msg, .. } = reply;
+        if let VrMsg::ClientReply {
+                   request_num: reply_req_num,
+                   value,
+                   ..
+               } = msg {
             let _ = safe_assert_eq!(reply_req_num, request_num, op);
             return Ok((request_num, op, value));
         }
@@ -114,25 +116,26 @@ fn match_client_reply(request: VrMsg, reply: VrEnvelope)
 pub fn assert_successful_create(scheduler: &Scheduler,
                                 path: String,
                                 request_num: u64,
-                                ty: NodeType) -> Result<(), String>
-{
-    try!(assert_majority_of_nodes_contain_op(scheduler, request_num));
-    try!(assert_primary_has_committed_op(scheduler, request_num));
+                                ty: NodeType)
+                                -> Result<(), String> {
+    assert_majority_of_nodes_contain_op(scheduler, request_num)?;
+    assert_primary_has_committed_op(scheduler, request_num)?;
     assert_path_exists_in_primary_backend(scheduler, path.clone(), ty)
 }
 
 pub fn assert_successful_put_or_get(scheduler: &Scheduler,
                                     path: String,
                                     request_num: u64,
-                                    data: Vec<u8>) -> Result<(), String>
-{
-    try!(assert_majority_of_nodes_contain_op(scheduler, request_num));
-    try!(assert_primary_has_committed_op(scheduler, request_num));
+                                    data: Vec<u8>)
+                                    -> Result<(), String> {
+    assert_majority_of_nodes_contain_op(scheduler, request_num)?;
+    assert_primary_has_committed_op(scheduler, request_num)?;
     assert_data_matches_primary_backend(scheduler, path, data)
 }
 
 pub fn assert_majority_of_nodes_contain_op(scheduler: &Scheduler,
-                                           request_num: u64) -> Result<(), String> {
+                                           request_num: u64)
+                                           -> Result<(), String> {
     let mut contained_in_log = 0;
     for r in &scheduler.new_config.replicas {
         match scheduler.get_state(&r) {
@@ -140,20 +143,20 @@ pub fn assert_majority_of_nodes_contain_op(scheduler: &Scheduler,
                 if is_client_request_last_in_log(ctx, request_num) {
                     contained_in_log += 1;
                 }
-            },
-            None => ()
+            }
+            None => (),
         }
     }
     safe_assert!(contained_in_log >= scheduler.quorum())
 }
 
 pub fn assert_primary_has_committed_op(scheduler: &Scheduler,
-                                       request_num: u64) -> Result<(), String>
-{
+                                       request_num: u64)
+                                       -> Result<(), String> {
     if let Some(ref primary) = scheduler.primary {
         let (state, ctx) = scheduler.get_state(primary).unwrap();
-        try!(safe_assert_eq!(state, "primary"));
-        try!(safe_assert_eq!(ctx.op, ctx.commit_num));
+        safe_assert_eq!(state, "primary")?;
+        safe_assert_eq!(ctx.op, ctx.commit_num)?;
         safe_assert!(is_client_request_last_in_log(&ctx, request_num))
     } else {
         fail!()
@@ -162,18 +165,18 @@ pub fn assert_primary_has_committed_op(scheduler: &Scheduler,
 
 fn assert_data_matches_primary_backend(scheduler: &Scheduler,
                                        path: String,
-                                       data: Vec<u8>) -> Result<(), String>
-{
+                                       data: Vec<u8>)
+                                       -> Result<(), String> {
     if let Some(ref primary) = scheduler.primary {
         let (_, ctx) = scheduler.get_state(primary).unwrap();
         match ctx.backend.tree.blob_get(path) {
-            Ok(Reply {value, ..}) => {
+            Ok(Reply { value, .. }) => {
                 if let Value::Blob(blob) = value {
                     return safe_assert_eq!(blob, data);
                 }
                 fail!()
-            },
-            _ => fail!()
+            }
+            _ => fail!(),
         }
     } else {
         fail!()
@@ -182,13 +185,16 @@ fn assert_data_matches_primary_backend(scheduler: &Scheduler,
 
 fn assert_path_exists_in_primary_backend(scheduler: &Scheduler,
                                          path: String,
-                                         ty: NodeType) -> Result<(), String>
-{
+                                         ty: NodeType)
+                                         -> Result<(), String> {
     if let Some(ref primary) = scheduler.primary {
         let ctx = scheduler.get_state(primary).unwrap().1.clone();
         if ctx.backend.tree.find(&path, ty.into()).is_err() {
             // Check to see if it was already created as a directory
-            if ctx.backend.tree.find(&path, vertree::NodeType::Directory).is_err() {
+            if ctx.backend
+                  .tree
+                  .find(&path, vertree::NodeType::Directory)
+                  .is_err() {
                 fail!()
             }
         }
@@ -198,9 +204,7 @@ fn assert_path_exists_in_primary_backend(scheduler: &Scheduler,
     }
 }
 
-fn assert_element_not_found_primary(scheduler: &Scheduler,
-                                    path: String) -> Result<(), String>
-{
+fn assert_element_not_found_primary(scheduler: &Scheduler, path: String) -> Result<(), String> {
     if let Some(ref primary) = scheduler.primary {
         let (_, ctx) = scheduler.get_state(primary).unwrap();
         safe_assert!(ctx.backend.tree.blob_get(path).is_err())
@@ -210,13 +214,14 @@ fn assert_element_not_found_primary(scheduler: &Scheduler,
 }
 
 fn is_client_request_last_in_log(ctx: &VrCtx, request_num: u64) -> bool {
-    if ctx.op == 0 { return false; }
+    if ctx.op == 0 {
+        return false;
+    }
     let ref msg = ctx.log[(ctx.op - 1) as usize];
-    if let &VrMsg::ClientRequest {request_num: logged_num, ..} = msg {
+    if let &VrMsg::ClientRequest { request_num: logged_num, .. } = msg {
         if request_num == logged_num {
             return true;
         }
     }
     false
 }
-

--- a/tests/utils/vr_fsm_constraints.rs
+++ b/tests/utils/vr_fsm_constraints.rs
@@ -28,35 +28,38 @@ fn transitions(c: &mut Constraints<VrTypes>) {
     transition!(c, "primary" => "primary", primary_to_primary);
 }
 
-/// All assertions pertaining to a transition from "primary" state to "primary" state
+/// All assertions pertaining to a transition from "primary" state to "primary"
+/// state
 fn primary_to_primary(init_ctx: &VrCtx,
                       final_ctx: &VrCtx,
                       envelope: &VrEnvelope,
-                      output: &Vec<FsmOutput>) -> Result<(), String> {
-   let s = "Transition from primary to primary";
+                      output: &Vec<FsmOutput>)
+                      -> Result<(), String> {
+    let s = "Transition from primary to primary";
 
-   if let Some(view) = envelope.msg.get_view() {
-       check!(s, view <= final_ctx.view);
-   }
+    if let Some(view) = envelope.msg.get_view() {
+        check!(s, view <= final_ctx.view);
+    }
 
-   if let Some(epoch) = envelope.msg.get_epoch() {
-       check!(s, epoch <= final_ctx.epoch);
-   }
+    if let Some(epoch) = envelope.msg.get_epoch() {
+        check!(s, epoch <= final_ctx.epoch);
+    }
 
-   check!(s, final_ctx.last_normal_view == final_ctx.view);
-   check!(s, final_ctx.recovery_state.is_none());
-   check!(s, final_ctx.view_change_state.is_none());
-   check!(s, final_ctx.last_normal_view == final_ctx.view);
-   check!(s, final_ctx.primary.as_ref() == Some(&final_ctx.pid));
+    check!(s, final_ctx.last_normal_view == final_ctx.view);
+    check!(s, final_ctx.recovery_state.is_none());
+    check!(s, final_ctx.view_change_state.is_none());
+    check!(s, final_ctx.last_normal_view == final_ctx.view);
+    check!(s, final_ctx.primary.as_ref() == Some(&final_ctx.pid));
 
-   check!(s, init_ctx.epoch == final_ctx.epoch);
+    check!(s, init_ctx.epoch == final_ctx.epoch);
 
-   if let VrMsg::DoViewChange {view, ..} = envelope.msg {
-       if output.len() == 0 {
-           check!(s, view <= final_ctx.view);
-       } else {
-           check!(s, view == final_ctx.view);
-       }
-   }
-   Ok(())
+    if let VrMsg::DoViewChange { view, .. } =
+        envelope.msg {
+        if output.len() == 0 {
+            check!(s, view <= final_ctx.view);
+        } else {
+            check!(s, view == final_ctx.view);
+        }
+    }
+    Ok(())
 }

--- a/tests/utils/vr_invariants.rs
+++ b/tests/utils/vr_invariants.rs
@@ -1,24 +1,22 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains assertion functions around VR protocol invariants. It's general enough to
+//! This module contains assertion functions around VR protocol invariants.
+//! It's general enough to
 //! be used from multiple tests.
 
 use std::u64::MAX;
 use haret::vr::VrCtx;
 
 pub fn assert_single_primary_per_epoch_view(states: &Vec<(&'static str, VrCtx)>)
-    -> Result<(), String>
-{
+                                            -> Result<(), String> {
     // List of epoch/views for all primaries
     let mut epoch_view = None;
     for &(state, ref ctx) in states {
         if state == "primary" {
             match epoch_view {
                 None => epoch_view = Some((ctx.epoch, ctx.view)),
-                Some((epoch, view)) => {
-                    return safe_assert!(epoch != ctx.epoch || view != ctx.view)
-                }
+                Some((epoch, view)) => return safe_assert!(epoch != ctx.epoch || view != ctx.view),
             }
         }
     }
@@ -27,8 +25,7 @@ pub fn assert_single_primary_per_epoch_view(states: &Vec<(&'static str, VrCtx)>)
 
 pub fn assert_minority_of_nodes_recovering(quorum: usize,
                                            states: &Vec<(&'static str, VrCtx)>)
-    -> Result<(), String>
-{
+                                           -> Result<(), String> {
     let mut recovering_count = 0;
     for &(state, _) in states {
         if state == "recovery" {
@@ -40,15 +37,16 @@ pub fn assert_minority_of_nodes_recovering(quorum: usize,
 
 pub fn assert_quorum_of_logs_equal_up_to_smallest_commit(quorum: usize,
                                                          states: &Vec<(&'static str, VrCtx)>)
-    -> Result<(), String>
-{
+                                                         -> Result<(), String> {
     let mut smallest_commit: u64 = MAX;
     for &(_, ref ctx) in states {
         if ctx.commit_num < smallest_commit {
             smallest_commit = ctx.commit_num;
         }
     }
-    if smallest_commit == 0 { return Ok(()) }
+    if smallest_commit == 0 {
+        return Ok(());
+    }
 
     let mut slice = None;
     let mut count = 0;
@@ -59,10 +57,10 @@ pub fn assert_quorum_of_logs_equal_up_to_smallest_commit(quorum: usize,
                     // We define the log prefix we will check in the next iteration
                     slice = Some(&ctx.log[0..smallest_commit as usize]);
                     count += 1;
-                },
+                }
                 Some(s) => {
                     // Are the log prefixes the same?
-                    try!(safe_assert_eq!(s, &ctx.log[0..smallest_commit as usize]));
+                    safe_assert_eq!(s, &ctx.log[0..smallest_commit as usize])?;
                     count += 1;
                 }
             }


### PR DESCRIPTION
Used `make format` to format code according to project's rustfmt
settings.