### PR TITLE
Remove unneeded custom_derive feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(custom_derive, plugin)]
-
 // Crates we don't manage
 extern crate rand;
 extern crate libc;


### PR DESCRIPTION
This, along with https://github.com/justinsheehy/vertree/pull/15, will get Haret compiling with the latest Stable Rust compiler.