### PR TITLE
Implement view change optimizations in RFC 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ dev/%: build
 	cp config.toml $@
 	cd $@; \
 	 rm -rf nonces; \
-	 $(PWD)/target/debug/devconfig $(notdir $@)
+	 $(PWD)/target/debug/haret-devconfig $(notdir $@)
 
 # Start a single node (e.g. `make start-dev1`)
 start-dev%:

--- a/haret/src/vr/replica.rs
+++ b/haret/src/vr/replica.rs
@@ -4,7 +4,7 @@
 use rabble::{self, Process, Pid, CorrelationId, Envelope};
 use msg::Msg;
 use vr::vr_fsm::VrState;
-use vr::vr_ctx::{VrCtx, DEFAULT_PRIMARY_TICK_MS};
+use vr::vr_ctx::VrCtx;
 use vr::states::{Primary, Backup, Recovery, Reconfiguration};
 use disk_msgs::{DiskReq, DiskRpy};
 use super::super::admin::{AdminReq, AdminRpy};
@@ -30,7 +30,7 @@ impl Replica {
     fn start_initial(&mut self) {
        let ctx = self.ctx.take().unwrap();
        if self.pid == ctx.compute_primary() {
-           self.state = Some(VrState::Primary(Primary::new(ctx, DEFAULT_PRIMARY_TICK_MS)));
+           self.state = Some(VrState::Primary(Primary::new(ctx)));
        } else {
            self.state = Some(VrState::Backup(Backup::new(ctx)));
        };

--- a/haret/src/vr/states/start_view.rs
+++ b/haret/src/vr/states/start_view.rs
@@ -28,7 +28,7 @@ impl Transition for StartView {
         match msg {
             VrMsg::StartViewChange(msg) => self.handle_start_view_change(msg, from, output),
             VrMsg::DoViewChange(msg) => self.handle_do_view_change(msg, from, output),
-            VrMsg::StartView(msg) => view_change::handle_start_view(self, msg, output),
+            VrMsg::StartView(msg) => view_change::handle_start_view(self, msg, cid, output),
             VrMsg::Tick => view_change::handle_tick(self, output),
             VrMsg::Prepare(msg) => {
                 up_to_date!(self, from, msg, cid, output);

--- a/haret/src/vr/states/start_view_change.rs
+++ b/haret/src/vr/states/start_view_change.rs
@@ -30,7 +30,7 @@ impl Transition for StartViewChange {
         match msg {
             VrMsg::StartViewChange(msg) => self.handle_start_view_change(msg, from, output),
             VrMsg::DoViewChange(msg) => self.handle_do_view_change(msg, from, output),
-            VrMsg::StartView(msg) => view_change::handle_start_view(self, msg, output),
+            VrMsg::StartView(msg) => view_change::handle_start_view(self, msg, cid, output),
             VrMsg::Tick => view_change::handle_tick(self, output),
             VrMsg::Prepare(msg) => {
                 up_to_date!(self, from, msg, cid, output);
@@ -169,7 +169,8 @@ impl StartViewChange {
             view: self.ctx.view,
             op: self.ctx.op,
             last_normal_view: self.ctx.last_normal_view,
-            log: self.ctx.log.clone(),
+            log_start: self.ctx.global_min_accept,
+            log_tail: self.ctx.get_log_tail(),
             commit_num: self.ctx.commit_num
         }.into()
     }

--- a/haret/src/vr/states/state_transfer.rs
+++ b/haret/src/vr/states/state_transfer.rs
@@ -84,8 +84,10 @@ impl StateTransfer {
         for m in log_tail {
             self.ctx.log.push(m);
         }
+        let cid = CorrelationId::pid(self.ctx.pid.clone());
         let mut backup = Backup::new(self.ctx);
         backup.set_primary(output);
+        backup.send_prepare_ok(cid, output);
         backup.commit(commit_num, output)
     }
 

--- a/haret/src/vr/states/utils/prepare_requests.rs
+++ b/haret/src/vr/states/utils/prepare_requests.rs
@@ -14,7 +14,7 @@ pub struct Request {
     replies: HashSet<Pid>,
 
     // Note that deserialization will return the wrong time.
-    // This is only used in debuggin goutput though.
+    // This is only used in debugging output though.
     #[serde(skip_serializing, skip_deserializing, default = "now")]
     timeout: SteadyTime
 }
@@ -41,6 +41,10 @@ impl PrepareRequests {
             lowest_op: 1,
             requests: VecDeque::new(),
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_empty()
     }
 
     pub fn new_prepare(&mut self, op: u64, correlation_id: CorrelationId) {
@@ -87,12 +91,5 @@ impl PrepareRequests {
         let lowest_op = self.lowest_op;
         self.lowest_op = op + 1;
         self.requests.drain(0..(op - lowest_op + 1) as usize).collect()
-    }
-
-    pub fn expired(&self) -> bool {
-        match self.requests.front() {
-            Some(request) => request.timeout > SteadyTime::now(),
-            None => false
-        }
     }
 }

--- a/haret/src/vr/vr_msg.rs
+++ b/haret/src/vr/vr_msg.rs
@@ -115,7 +115,8 @@ msg!(DoViewChange {
     view: u64,
     op: u64,
     last_normal_view: u64,
-    log: Vec<ClientOp>,
+    log_start: u64,
+    log_tail: Vec<ClientOp>,
     commit_num: u64
 });
 
@@ -123,7 +124,8 @@ msg!(StartView {
     epoch: u64,
     view: u64,
     op: u64,
-    log: Vec<ClientOp>,
+    log_start: u64,
+    log_tail: Vec<ClientOp>,
     commit_num: u64
 });
 
@@ -132,6 +134,7 @@ msg!(Prepare {
     view: u64,
     op: u64,
     commit_num: u64,
+    global_min_accept: u64,
     msg: ClientOp
 });
 
@@ -144,7 +147,8 @@ msg!(PrepareOk {
 msg!(Commit {
     epoch: u64,
     view: u64,
-    commit_num: u64
+    commit_num: u64,
+    global_min_accept: u64
 });
 
 msg!(GetState {
@@ -170,6 +174,8 @@ msg!(RecoveryResponse {
     epoch: u64,
     view: u64,
     nonce: u64,
+    global_min_accept: u64,
+
     // The following fields are only valid when sent by the Primary
     op: Option<u64>,
     commit_num: Option<u64>,

--- a/haret/tests/utils/macros.rs
+++ b/haret/tests/utils/macros.rs
@@ -49,3 +49,16 @@ macro_rules! fail {
         safe_assert!()
     }
 }
+
+#[macro_export]
+macro_rules! assert_contains {
+    ($container:expr, $key:expr) => {
+        if $container.contains($key) {
+            let res: Result<(), String> = Ok(());
+            res
+        } else {
+             return Err(format!("Assert failure: container = {:?}, key = {:?} File: {}, Line: {}",
+                     $container, $key, file!(), line!()))
+        }
+    }
+}

--- a/haret/tests/utils/mod.rs
+++ b/haret/tests/utils/mod.rs
@@ -14,3 +14,8 @@ pub mod op_invariants;
 
 #[allow(dead_code)]
 pub mod scheduler;
+
+#[allow(dead_code)]
+mod model;
+
+pub use self::model::Model;

--- a/haret/tests/utils/model.rs
+++ b/haret/tests/utils/model.rs
@@ -1,0 +1,168 @@
+// Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use rabble::Pid;
+use haret::vr::{ClientOp, VrState};
+use super::arbitrary::{Op, ClientRequest};
+
+/// This is a model of the state of a VR replica set under test. It doesn't represent a particular
+/// replica, but rather properties of the system as it transitions through various states and
+/// messages.
+pub struct Model {
+    client_req_num: u64,
+    replicas: Vec<Pid>,
+    quorum: u64,
+    crashed: u64,
+    possible_views: Vec<u64>,
+
+    possible_primary_commit_num: Vec<u64>,
+    possible_backup_commit_num: Vec<u64>,
+    possible_primary_min_accept: Vec<u64>,
+    possible_backup_min_accept: Vec<u64>,
+
+    // This is the log at every alive replica, since messages are not dropped and there are no
+    // partitions in the current model
+    log: Vec<ClientOp>
+}
+
+impl Model {
+
+    /// Create a new model
+    pub fn new(mut replicas: Vec<Pid>) -> Model {
+        replicas.sort();
+        Model {
+            client_req_num: 0,
+            quorum: replicas.len() as u64 / 2 + 1,
+            replicas: replicas,
+            crashed: 0,
+            possible_views: vec![0],
+            possible_primary_commit_num: vec![0],
+            possible_backup_commit_num: vec![0],
+            possible_primary_min_accept: vec![0],
+            possible_backup_min_accept: vec![0],
+            log: Vec::new()
+        }
+    }
+
+    /// Update the model as a result of an operation
+    pub fn update(&mut self, op: Op) {
+        match op {
+            Op::ClientRequest(ClientRequest(mut req)) => {
+                self.client_req_num += 1;
+                req.request_num = self.client_req_num;
+                self.log.push(req.into());
+
+                self.possible_backup_commit_num = self.possible_primary_commit_num.clone();
+
+                // In our current model we always commit operations
+                self.possible_primary_commit_num = vec![self.log.len() as u64];
+
+                self.possible_backup_min_accept = self.possible_primary_min_accept.clone();
+
+                if self.crashed == 0 {
+                    self.possible_primary_min_accept = vec![self.log.len() as u64];
+                }
+            }
+            Op::Commit => {
+                self.possible_backup_commit_num = self.possible_primary_commit_num.clone();
+
+                // A prepare will be rebroadcast and commit if there are uncommitted ops
+                self.possible_primary_commit_num = vec![self.log.len() as u64];
+                self.possible_backup_min_accept = self.possible_primary_min_accept.clone();
+            }
+            Op::ViewChange => {
+                self.update_view();
+                self.possible_backup_commit_num.extend(&self.possible_primary_commit_num);
+                self.possible_backup_commit_num.sort();
+                self.possible_backup_commit_num.dedup();
+                self.possible_primary_commit_num = self.possible_backup_commit_num.clone();
+
+                self.possible_backup_min_accept.extend(&self.possible_primary_min_accept);
+                self.possible_backup_min_accept.sort();
+                self.possible_backup_min_accept.dedup();
+                self.possible_primary_min_accept = self.possible_backup_min_accept.clone();
+            }
+            Op::CrashBackup => {
+                if self.replicas.len() as u64 - self.crashed != self.quorum {
+                    self.crashed += 1;
+                }
+            }
+            Op::CrashPrimary => {
+                if self.replicas.len() as u64 - self.crashed != self.quorum {
+                    self.crashed += 1;
+                    self.update_view();
+                    self.possible_primary_commit_num = self.possible_backup_commit_num.clone();
+                    self.possible_primary_min_accept = self.possible_backup_min_accept.clone();
+                }
+            }
+            Op::Restart => {
+                // A restarting replica will learn of the primary commit num. Therefore backups may
+                // diverge.
+                self.possible_backup_commit_num.extend(&self.possible_primary_commit_num);
+                self.possible_backup_commit_num.sort();
+                self.possible_backup_commit_num.dedup();
+
+                // A restarting replica will learn of the primary min accept, therefore backups may
+                // diverge.
+                self.possible_backup_min_accept.extend(&self.possible_primary_min_accept);
+                self.possible_backup_min_accept.sort();
+                self.possible_backup_min_accept.dedup();
+
+                if self.crashed == 1 {
+                    // Recovering replicas send PrepareOk to the primary allowing it to learn of the
+                    // latest accepted prepare
+                    self.possible_primary_min_accept = vec![self.log.len() as u64];
+                }
+
+                if self.crashed != 0 {
+                    self.crashed -= 1;
+                }
+            }
+        }
+    }
+
+    /// Compare the model with the actual states of the replicas.
+    ///
+    /// Note that this method is mutable because some members contain multiple possible values that
+    /// can be collapsed during checking to known values.
+    pub fn check(&mut self, states: &[VrState]) -> Result<(), String> {
+        for ref state in states {
+           safe_assert!(self.possible_views.contains(&state.ctx().view))?;
+           self.possible_views = vec![state.ctx().view];
+           safe_assert_eq!(self.log, state.ctx().log)?;
+           match **state {
+               VrState::Primary(_) => {
+                   assert_contains!(self.possible_primary_commit_num, &state.ctx().commit_num)?;
+                   // Reset the possible primary value with the known result
+                   self.possible_primary_commit_num = vec![state.ctx().commit_num];
+
+                   assert_contains!(self.possible_primary_min_accept,
+                                    &state.ctx().global_min_accept)?;
+                   // Reset the possible primary value with the known result
+                   self.possible_primary_min_accept = vec![state.ctx().global_min_accept];
+               },
+               VrState::Backup(_) => {
+                   assert_contains!(self.possible_backup_commit_num, &state.ctx().commit_num)?;
+                   assert_contains!(self.possible_backup_min_accept,
+                                    &state.ctx().global_min_accept)?;
+               },
+               _ => fail!()
+           }
+        }
+        Ok(())
+    }
+
+    /// With no partitions, at each update there is only going to be one view,
+    /// because at each call to check, the possible views will be collapsed to a known
+    /// view.
+    fn update_view(&mut self) {
+        assert_eq!(self.possible_views.len(), 1);
+        let mut view = self.possible_views.pop().unwrap();
+        view += 1;
+        self.possible_views.push(view);
+        for _ in 0..self.crashed {
+            view += 1;
+            self.possible_views.push(view);
+        }
+    }
+}

--- a/haret/tests/utils/vr_invariants.rs
+++ b/haret/tests/utils/vr_invariants.rs
@@ -68,3 +68,12 @@ pub fn assert_quorum_of_logs_equal_up_to_smallest_commit(quorum: usize,
     }
     safe_assert!(count >= quorum)
 }
+
+pub fn assert_global_min_accept(states: &Vec<VrState>) -> Result<(), String> {
+    for ref state in states {
+        let ctx = state.ctx();
+        safe_assert!(ctx.commit_num >= ctx.global_min_accept)?;
+        safe_assert!(ctx.commit_num >= ctx.global_min_accept)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Additionally add some other protocol fixes/enhancements:
 1. Ensure PrepareOk message for last log entry gets sent after state transfer
 2. Rebroadcast prepare if primary has not received quorum
 3. Send PrepareOk for last log entry after view change and recovery

Some notes about the above enhancements:

 2. When there are outstanding uncommitted operations, and a primary timeout
    occurs resend the prepare instead of a commit message to ensure it
    eventually commits even if no more new client requests are received.

    Track the broadcast in `PrepareRequests` using the pid of the primary if
    it wasn't the one to receive the client request, such as after a view
    change. On commit filter on this pid so that a client reply is not sent from
    the primary to itself.

    If a backup receives a Prepare message for the last operation in it's
    log it sends a PrepareOk so that the primary can commit in case prior
    PrepareOk messages were dropped.

 3. When becoming a backup, send a PrepareOk message for the last log entry
    to the primary. This is specified in the paper for view change, but not
    recovery. For recovery this allows the primary to update it's
    min_accepted map without having to wait for a new client request which
    may not come for quite a while. Note that this message can also be
    dropped, but as it is an optimization it is still safe.

# Testing
Add a model of the VR replicas for QC tests

An abstract model of the state of a VR replica set has been created for use in quickcheck tests.
The state of all the replicas is compared against the model after each operation to ensure
correctness.

The primary idle timeout has been moved from the primary state into the context so that any changes
to its configuration can carry across state transitions.

Add a history member to the scheduler that allows us to track messages and operations throughout
tests and then only show the failing history. This is especially useful in QC tests when we only
want to display the history for the shrunk test.

Fix make-devrel to use the right binary to generate configuration.