### PR TITLE
TreeOp::SetSupersetSet should call `set_superset`.

### DIFF
--- a/haret/src/vr/backend.rs
+++ b/haret/src/vr/backend.rs
@@ -138,7 +138,7 @@ impl VrBackend {
                 reply.into()
             },
             TreeOp::SetSupersetSet {path, set} => {
-                let reply = self.tree.set_subset(path, None, Some(set))?;
+                let reply = self.tree.set_superset(path, None, Some(set))?;
                 reply.into()
             }
         };


### PR DESCRIPTION
I'm not sure if this is quite correct, but this look like a copy-paste error.