### PR TITLE
Get haret to be clippy-clean, and check clippy on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,36 @@ rust:
   - stable
   - beta
   - nightly
+
+before_script:
+  - pip install 'travis-cargo<0.2' --user
+  - (cd haret && travis-cargo --only nightly install clippy -- --force)
+
 script:
-  - (cd haret && cargo build --verbose)
-  - (cd haret && cargo test --verbose)
+  - (cd haret && travis-cargo build -- --verbose)
+  - (cd haret && travis-cargo test -- --verbose)
+  - (cd haret && travis-cargo --only nightly clippy)
 
-  - (cd haret-admin && cargo build --verbose)
-  - (cd haret-admin && cargo test --verbose)
+  - (cd haret-admin && travis-cargo build -- --verbose)
+  - (cd haret-admin && travis-cargo test -- --verbose)
+  - (cd haret-admin && travis-cargo --only nightly clippy)
 
-  - (cd haret-client && cargo build --verbose)
-  - (cd haret-client && cargo test --verbose)
+  - (cd haret-client && travis-cargo build -- --verbose)
+  - (cd haret-client && travis-cargo test -- --verbose)
+  - (cd haret-client && travis-cargo --only nightly clippy)
 
-  - (cd haret-cli-client && cargo build --verbose)
-  - (cd haret-cli-client && cargo test --verbose)
+  - (cd haret-cli-client && travis-cargo build -- --verbose)
+  - (cd haret-cli-client && travis-cargo test -- --verbose)
+  - (cd haret-cli-client && travis-cargo --only nightly clippy)
 
-  - (cd haret-devconfig && cargo build --verbose)
-  - (cd haret-devconfig && cargo test --verbose)
+  - (cd haret-devconfig && travis-cargo build -- --verbose)
+  - (cd haret-devconfig && travis-cargo test -- --verbose)
+  - (cd haret-devconfig && travis-cargo --only nightly clippy)
 
-  - (cd haret-server && cargo build --verbose)
-  - (cd haret-server && cargo test --verbose)
+  - (cd haret-server && travis-cargo build -- --verbose)
+  - (cd haret-server && travis-cargo test -- --verbose)
+  - (cd haret-server && travis-cargo --only nightly clippy)
+
+env:
+  global:
+  - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/haret/src/lib.rs
+++ b/haret/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg_attr(feature="cargo-clippy", allow(too_many_arguments))]
+#![cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
+
 // Crates we don't manage
 extern crate rand;
 extern crate libc;

--- a/haret/src/vr/states/common/normal.rs
+++ b/haret/src/vr/states/common/normal.rs
@@ -67,12 +67,11 @@ pub fn handle_start_view<T: State>(state: T,
 }
 
 pub fn handle_get_state<T: State>(state: T,
-                                  msg: GetState,
+                                  GetState { epoch, view, op }: GetState,
                                   from: Pid,
                                   cid: CorrelationId,
                                   output: &mut Vec<Envelope<Msg>>) -> VrState
 {
-    let GetState {epoch, view, op} = msg;
     if epoch != state.borrow_ctx().epoch || view != state.borrow_ctx().view {
         return state.into()
     }

--- a/haret/tests/static_membership_qc.rs
+++ b/haret/tests/static_membership_qc.rs
@@ -1,6 +1,10 @@
 // Copyright © 2016-2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
+#![cfg_attr(feature="cargo-clippy", allow(collapsible_if))]
+#![cfg_attr(feature="cargo-clippy", allow(while_let_on_iterator))]
+
 #[macro_use]
 extern crate quickcheck;
 extern crate uuid;

--- a/haret/tests/static_membership_unit.rs
+++ b/haret/tests/static_membership_unit.rs
@@ -9,6 +9,10 @@
 //! invariants are maintained. This is in addition to the FSM level constraints that operate on a
 //! single FSM.
 
+#![cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
+#![cfg_attr(feature="cargo-clippy", allow(collapsible_if))]
+#![cfg_attr(feature="cargo-clippy", allow(while_let_on_iterator))]
+
 extern crate uuid;
 extern crate haret;
 extern crate quickcheck;


### PR DESCRIPTION
This disables a few lints, that I felt were a little unnecessary, and
could be addressed later:

* [large_enum_variant](https://github.com/Manishearth/rust-clippy/wiki#large_enum_variant)
* [collapsible_if](https://github.com/Manishearth/rust-clippy/wiki#collapsible_if)
* [while_let_on_iterator](https://github.com/Manishearth/rust-clippy/wiki#while_let_on_iterator)